### PR TITLE
Ensure session store table auto-creates

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -11,8 +11,7 @@ const knexsessions = Knex(config.sessionstore);
 
 const sessionStore = new ConnectSessionKnexStore({
   knex: knexsessions,
-  tablename: 'sessions',
-  createTable: false
+  tableName: 'sessions'
 });
 
 const context = createServerContext({


### PR DESCRIPTION
## Summary
- allow connect-session-knex to create the sessions table automatically when it is missing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5b3231d20832e9dcf693ea8018806