### PR TITLE
Fix default admin password hash

### DIFF
--- a/seeds/001_default_admin.cjs
+++ b/seeds/001_default_admin.cjs
@@ -8,7 +8,7 @@ exports.seed = async function seed(knex) {
     await knex('users').insert({
       Name: 'Admin',
       Email: 'admin@nodervisor',
-      Password: '$2a$10$OI5bfzPATM2358vQlDYKweliWYI2FyJwqsDJUMXuqaSzM.7vNa3xu',
+      Password: '$2b$10$JE/okr6K8iN2P3oQg0YLaOZ0pkKf.ZtVIaNHv7bsXw3oPmRF8eXAG',
       Role: 'Admin'
     });
   }


### PR DESCRIPTION
## Summary
- update the default admin seed to use a bcrypt hash that matches the documented admin password

## Testing
- npm test -- --runTestsByPath __tests__/data/users.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d5b9bb39b4832ebabcb49b7625ff2c