### PR TITLE
Fix CSP inline script bootstrapping

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -5,7 +5,22 @@ import App from './App.jsx';
 import './styles/tokens.css';
 
 const container = document.getElementById('app-root');
-const initialState = window.__APP_STATE__ ?? {};
+
+function getInitialState() {
+  const stateElement = document.getElementById('app-state');
+
+  if (stateElement?.textContent) {
+    try {
+      return JSON.parse(stateElement.textContent);
+    } catch (error) {
+      console.error('Failed to parse initial app state', error);
+    }
+  }
+
+  return window.__APP_STATE__ ?? {};
+}
+
+const initialState = getInitialState();
 
 if (container) {
   const root = createRoot(container);

--- a/server/renderAppPage.js
+++ b/server/renderAppPage.js
@@ -43,7 +43,7 @@ export function renderAppPage({ title = 'Nodervisor', dashboardAssets = null, se
   </head>
   <body>
     <div id="app-root"></div>
-    <script>window.__APP_STATE__ = ${serializedState};</script>
+    <script id="app-state" type="application/json">${serializedState}</script>
     ${scripts}
   </body>
 </html>`;


### PR DESCRIPTION
## Summary
- replace the inline application state bootstrap script with a CSP-compliant JSON script tag
- load the initial application state on the client by parsing the JSON payload instead of relying on a global

## Testing
- npm test -- --passWithNoTests
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5ba338c5c832ebe8d5beea4db9599