### PR TITLE
Ensure CSRF token is sent with JSON requests

### DIFF
--- a/__tests__/client/apiClient.test.js
+++ b/__tests__/client/apiClient.test.js
@@ -1,0 +1,46 @@
+import { jest } from '@jest/globals';
+
+import { requestJson } from '../../client/src/apiClient.js';
+
+describe('requestJson', () => {
+  const originalFetch = global.fetch;
+  const originalDocument = global.document;
+
+  beforeEach(() => {
+    global.document = { cookie: 'XSRF-TOKEN=csrf-token;' };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      json: async () => ({})
+    });
+  });
+
+  afterEach(() => {
+    if (typeof originalDocument === 'undefined') {
+      delete global.document;
+    } else {
+      global.document = originalDocument;
+    }
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('includes the CSRF token header when available', async () => {
+    await requestJson('/api/test');
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [, options] = fetch.mock.calls[0];
+    expect(options.headers.get('X-CSRF-Token')).toBe('csrf-token');
+  });
+
+  it('does not override an existing CSRF token header', async () => {
+    await requestJson('/api/test', {
+      headers: {
+        'X-CSRF-Token': 'provided-token'
+      }
+    });
+
+    const [, options] = fetch.mock.calls[0];
+    expect(options.headers.get('X-CSRF-Token')).toBe('provided-token');
+  });
+});

--- a/client/src/apiClient.js
+++ b/client/src/apiClient.js
@@ -6,6 +6,12 @@ export async function requestJson(url, options = {}) {
   if (!headers.has('Accept')) {
     headers.set('Accept', 'application/json');
   }
+  if (!headers.has('X-CSRF-Token')) {
+    const csrfToken = getCookieValue('XSRF-TOKEN');
+    if (csrfToken) {
+      headers.set('X-CSRF-Token', csrfToken);
+    }
+  }
 
   const response = await fetch(url, {
     credentials: 'same-origin',
@@ -30,6 +36,22 @@ export async function requestJson(url, options = {}) {
   }
 
   return payload?.data ?? payload;
+}
+
+function getCookieValue(name) {
+  if (typeof document === 'undefined' || typeof document.cookie !== 'string') {
+    return null;
+  }
+
+  const cookies = document.cookie.split(';');
+  for (const cookie of cookies) {
+    const [cookieName, ...rest] = cookie.trim().split('=');
+    if (cookieName === name) {
+      return decodeURIComponent(rest.join('='));
+    }
+  }
+
+  return null;
 }
 
 export function createAuthClient(endpoints = {}) {


### PR DESCRIPTION
## Summary
- automatically attach the CSRF token from the XSRF-TOKEN cookie to JSON API requests
- add unit tests covering the CSRF header behavior in the shared API client

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5ba890fec832ea15a4a7da1c1d30f