### PR TITLE
Require explicit admin seed credentials

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -59,3 +59,11 @@ DASHBOARD_ENTRY=src/main.jsx
 
 # Host cache behaviour
 HOST_REFRESH_INTERVAL_MS=300000
+
+# Bootstrap administrator seed configuration
+# ADMIN_SEED_EMAIL=admin@nodervisor
+# Provide either a plain-text password or a bcrypt hash before running `npm run seed`.
+# ADMIN_SEED_PASSWORD=change-me-soon
+# ADMIN_SEED_PASSWORD_HASH=$2b$12$exampleHashedValueReplaceMe
+# Optional: override the salt rounds used when hashing ADMIN_SEED_PASSWORD (defaults to 12)
+# ADMIN_SEED_SALT_ROUNDS=12

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ A Supervisord manager in node.js. Nodervisor provides a real-time web dashboard 
         DB_FILENAME=./nodervisor.sqlite
         SESSION_SECRET=use-a-long-random-string
 
+     Before seeding the database you must also configure credentials for the bootstrap administrator account. Provide either a plain-text password (it will be hashed during the seed) or a pre-computed bcrypt hash:
+
+        ADMIN_SEED_PASSWORD=change-me-soon
+        # or provide a hash instead of plain text
+        # ADMIN_SEED_PASSWORD_HASH=$2b$12$...
+
   3. Run the database migrations and seed data:
 
         npm run migrate
@@ -67,11 +73,7 @@ The session store uses the same connection details by default, but you can overr
   For instance:
     http://localhost:3000
 
-  3. Log in using the default credentials of:
-  	<ul>
-  		<li>Email: admin@nodervisor</li>
-  		<li>Password: admin</li>
-	</ul>
+  3. Log in using the administrator credentials you configured via `ADMIN_SEED_PASSWORD`/`ADMIN_SEED_PASSWORD_HASH`. The default email is `admin@nodervisor`, but you can override it with `ADMIN_SEED_EMAIL` when seeding.
 
   4. Navigate to the users page using the top menu. Change the admin credentials or add a new user and remove them.
 

--- a/seeds/001_default_admin.cjs
+++ b/seeds/001_default_admin.cjs
@@ -1,15 +1,62 @@
+const DEFAULT_EMAIL = 'admin@nodervisor';
+const DEFAULT_NAME = 'Admin';
+
+function resolveAdminCredentials() {
+  const email = process.env.ADMIN_SEED_EMAIL?.trim() || DEFAULT_EMAIL;
+  const passwordHash = process.env.ADMIN_SEED_PASSWORD_HASH?.trim();
+  const password = process.env.ADMIN_SEED_PASSWORD?.trim();
+
+  if (passwordHash) {
+    return { email, passwordHash };
+  }
+
+  if (!password) {
+    throw new Error(
+      'Set ADMIN_SEED_PASSWORD (plain text) or ADMIN_SEED_PASSWORD_HASH (bcrypt hash) before running the admin seed.'
+    );
+  }
+
+  return { email, password };
+}
+
+async function hashPasswordIfNeeded(credentials) {
+  if (credentials.passwordHash) {
+    return credentials.passwordHash;
+  }
+
+  const bcrypt = await import('bcrypt');
+  const saltRounds = Number(process.env.ADMIN_SEED_SALT_ROUNDS ?? 12);
+
+  if (!Number.isFinite(saltRounds) || saltRounds < 4) {
+    throw new Error('ADMIN_SEED_SALT_ROUNDS must be an integer >= 4 when provided.');
+  }
+
+  const hash = bcrypt.hash ?? bcrypt.default?.hash;
+
+  if (typeof hash !== 'function') {
+    throw new Error('Unable to load bcrypt hashing implementation.');
+  }
+
+  return hash(credentials.password, saltRounds);
+}
+
 /**
  * @param {import('knex')} knex
  */
 exports.seed = async function seed(knex) {
-  const existingAdmin = await knex('users').where('Email', 'admin@nodervisor').first();
+  const credentials = resolveAdminCredentials();
+  const existingAdmin = await knex('users').where('Email', credentials.email).first();
 
-  if (!existingAdmin) {
-    await knex('users').insert({
-      Name: 'Admin',
-      Email: 'admin@nodervisor',
-      Password: '$2b$10$JE/okr6K8iN2P3oQg0YLaOZ0pkKf.ZtVIaNHv7bsXw3oPmRF8eXAG',
-      Role: 'Admin'
-    });
+  if (existingAdmin) {
+    return;
   }
+
+  const passwordHash = await hashPasswordIfNeeded(credentials);
+
+  await knex('users').insert({
+    Name: DEFAULT_NAME,
+    Email: credentials.email,
+    Password: passwordHash,
+    Role: 'Admin'
+  });
 };


### PR DESCRIPTION
## Summary
- require operators to provide explicit credentials when seeding the default administrator account
- hash plaintext admin seed passwords at seed time and support providing precomputed bcrypt hashes
- update documentation and environment example with secure bootstrap instructions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5be3a974c832e9eeb0d71ccfc346a