### PR TITLE
Add role-based access levels and request access screen

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -7,6 +7,7 @@ import bcrypt from 'bcrypt';
 import { beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 import { createApp } from '../server/app.js';
+import { ROLE_ADMIN, ROLE_MANAGER, ROLE_NONE, ROLE_VIEWER } from '../shared/roles.js';
 
 const TEST_EMAIL = 'admin@example.com';
 const TEST_PASSWORD = 'correct-password';
@@ -73,7 +74,7 @@ function createMockSupervisordClient({ processSnapshots } = {}) {
   };
 }
 
-async function createTestApp({ userRole = 'Admin', supervisordClientOptions } = {}) {
+async function createTestApp({ userRole = ROLE_ADMIN, supervisordClientOptions } = {}) {
   const host = {
     idHost: 'alpha',
     idGroup: null,
@@ -312,7 +313,7 @@ describe('Nodervisor application', () => {
           id: expect.any(Number),
           name: expect.any(String),
           email: TEST_EMAIL,
-          role: 'Admin'
+          role: ROLE_ADMIN
         }
       }
     });
@@ -328,6 +329,60 @@ describe('Nodervisor application', () => {
           data: [{ name: 'app', group: 'app', state: 1 }]
         }
       }
+    });
+  });
+
+  it('allows managers to manage infrastructure endpoints', async () => {
+    const { app, hostRepository } = await createTestApp({ userRole: ROLE_MANAGER });
+    const agent = request.agent(app);
+
+    await login(agent);
+
+    hostRepository.listHosts.mockResolvedValueOnce([]);
+    const response = await agent.get('/api/v1/hosts');
+    expect(response.status).toBe(200);
+  });
+
+  it('prevents viewers from modifying infrastructure', async () => {
+    const { app, hostRepository } = await createTestApp({ userRole: ROLE_VIEWER });
+    const agent = request.agent(app);
+
+    await login(agent);
+
+    const response = await agent.get('/api/v1/hosts');
+    expect(response.status).toBe(403);
+    expect(hostRepository.listHosts).not.toHaveBeenCalled();
+  });
+
+  it('allows viewers to read supervisor state but blocks control actions', async () => {
+    const { app, client, host } = await createTestApp({ userRole: ROLE_VIEWER });
+    const agent = request.agent(app);
+
+    await login(agent);
+
+    const readResponse = await agent.get('/api/v1/supervisors');
+    expect(readResponse.status).toBe(200);
+    expect(client.getAllProcessInfo).toHaveBeenCalledTimes(1);
+
+    const controlResponse = await postWithCsrf(agent, '/api/v1/supervisors/control', {
+      host: host.idHost,
+      process: 'app',
+      action: 'restart'
+    });
+    expect(controlResponse.status).toBe(403);
+  });
+
+  it('requires an assigned role to access supervisor data', async () => {
+    const { app } = await createTestApp({ userRole: ROLE_NONE });
+    const agent = request.agent(app);
+
+    await login(agent);
+
+    const response = await agent.get('/api/v1/supervisors');
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      status: 'error',
+      error: { message: 'Insufficient privileges' }
     });
   });
 
@@ -452,13 +507,13 @@ describe('Nodervisor application', () => {
     const response = await postWithCsrf(agent, '/api/v1/users', {
       name: 'CLI User',
       email: 'cli@example.test',
-      role: 'User',
+      role: ROLE_VIEWER,
       password: 'temporary'
     });
 
     expect(response.status).toBe(201);
     const payload = userRepository.createUser.mock.calls[0][0];
-    expect(payload).toMatchObject({ name: 'CLI User', email: 'cli@example.test', role: 'User' });
+    expect(payload).toMatchObject({ name: 'CLI User', email: 'cli@example.test', role: ROLE_VIEWER });
     expect(await bcrypt.compare('temporary', payload.passwordHash)).toBe(true);
   });
 

--- a/__tests__/data/users.test.js
+++ b/__tests__/data/users.test.js
@@ -2,6 +2,7 @@ import knex from 'knex';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 
 import { createUsersRepository } from '../../data/users.js';
+import { ROLE_ADMIN, ROLE_MANAGER, ROLE_NONE, ROLE_VIEWER } from '../../shared/roles.js';
 
 let db;
 let usersRepository;
@@ -37,14 +38,14 @@ describe('users repository', () => {
       name: 'Ada Lovelace',
       email: 'ada@example.com',
       passwordHash: 'hashed',
-      role: 'Admin'
+      role: ROLE_ADMIN
     });
 
     expect(user).toEqual({
       id: expect.any(Number),
       name: 'Ada Lovelace',
       email: 'ada@example.com',
-      role: 'Admin'
+      role: ROLE_ADMIN
     });
 
     const stored = await db('users').first();
@@ -56,7 +57,7 @@ describe('users repository', () => {
       name: 'Grace Hopper',
       email: 'grace@example.com',
       passwordHash: 'hashed-password',
-      role: 'User'
+      role: ROLE_VIEWER
     });
 
     const user = await usersRepository.findByEmail('grace@example.com');
@@ -64,7 +65,7 @@ describe('users repository', () => {
       id: expect.any(Number),
       name: 'Grace Hopper',
       email: 'grace@example.com',
-      role: 'User',
+      role: ROLE_VIEWER,
       passwordHash: 'hashed-password'
     });
   });
@@ -74,20 +75,20 @@ describe('users repository', () => {
       name: 'Linus Torvalds',
       email: 'linus@example.com',
       passwordHash: 'initial',
-      role: 'User'
+      role: ROLE_NONE
     });
 
     const updated = await usersRepository.updateUser(user.id, {
       name: 'Linus',
       email: 'linus@example.com',
-      role: 'Admin'
+      role: ROLE_MANAGER
     });
 
     expect(updated).toEqual({
       id: user.id,
       name: 'Linus',
       email: 'linus@example.com',
-      role: 'Admin'
+      role: ROLE_MANAGER
     });
 
     const stored = await db('users').where('id', user.id).first();
@@ -99,13 +100,13 @@ describe('users repository', () => {
       name: 'Margaret Hamilton',
       email: 'margaret@example.com',
       passwordHash: 'before',
-      role: 'Admin'
+      role: ROLE_ADMIN
     });
 
     await usersRepository.updateUser(user.id, {
       name: 'Margaret Hamilton',
       email: 'margaret@example.com',
-      role: 'Admin',
+      role: ROLE_ADMIN,
       passwordHash: 'after'
     });
 
@@ -118,7 +119,7 @@ describe('users repository', () => {
       name: 'Barbara Liskov',
       email: 'barbara@example.com',
       passwordHash: 'secret',
-      role: 'User'
+      role: ROLE_VIEWER
     });
 
     const deleted = await usersRepository.deleteUser(user.id);

--- a/__tests__/routes/apiValidation.test.js
+++ b/__tests__/routes/apiValidation.test.js
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals
 import { createHostsApi } from '../../routes/api/hosts.js';
 import { createGroupsApi } from '../../routes/api/groups.js';
 import { createUsersApi } from '../../routes/api/users.js';
+import { ROLE_ADMIN, ROLE_VIEWER } from '../../shared/roles.js';
 
 describe('API validation middleware', () => {
   afterEach(() => {
@@ -122,7 +123,7 @@ describe('API validation middleware', () => {
 
     it('hashes the password when creating a user', async () => {
       const hashSpy = jest.spyOn(bcrypt, 'hash').mockResolvedValue('hashed-password');
-      const createdUser = { id: 1, name: 'Admin', email: 'admin@example.com', role: 'Admin' };
+      const createdUser = { id: 1, name: 'Admin', email: 'admin@example.com', role: ROLE_ADMIN };
       userRepository.createUser.mockResolvedValue(createdUser);
 
       const response = await request(app)
@@ -130,7 +131,7 @@ describe('API validation middleware', () => {
         .send({
           name: ' Admin ',
           email: ' admin@example.com ',
-          role: ' Admin ',
+          role: ` ${ROLE_ADMIN} `,
           password: 'super-secret'
         });
 
@@ -139,7 +140,7 @@ describe('API validation middleware', () => {
       expect(userRepository.createUser).toHaveBeenCalledWith({
         name: 'Admin',
         email: 'admin@example.com',
-        role: 'Admin',
+        role: ROLE_ADMIN,
         passwordHash: 'hashed-password'
       });
       hashSpy.mockRestore();
@@ -149,7 +150,7 @@ describe('API validation middleware', () => {
       const response = await request(app).put('/users/NaN').send({
         name: 'Test',
         email: 'test@example.com',
-        role: 'User'
+        role: ROLE_VIEWER
       });
 
       expect(response.status).toBe(400);

--- a/client/src/pages/RequestAccessPage.jsx
+++ b/client/src/pages/RequestAccessPage.jsx
@@ -1,0 +1,23 @@
+import { useSession } from '../App.jsx';
+import ui from '../styles/ui.module.css';
+
+export default function RequestAccessPage() {
+  const { user } = useSession();
+
+  return (
+    <section aria-labelledby="request-access-heading">
+      <header className={ui.sectionHeader}>
+        <h2 id="request-access-heading" className={ui.pageTitle}>
+          Access required
+        </h2>
+      </header>
+      <div className={ui.alert} role="status">
+        <p>Hi {user?.name ?? 'there'}!</p>
+        <p>
+          Your account is active, but no roles have been assigned yet. Please reach out to an administrator to request
+          viewer, manager, or admin access so you can use the dashboard.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/client/src/pages/UserFormPage.jsx
+++ b/client/src/pages/UserFormPage.jsx
@@ -3,14 +3,21 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { requestJson } from '../apiClient.js';
 import ui from '../styles/ui.module.css';
+import { ALL_ROLES, ROLE_VIEWER } from '../../shared/roles.js';
 
-const ROLES = ['Admin', 'User'];
+const ROLE_OPTIONS = ALL_ROLES;
+const DEFAULT_ROLE = ROLE_VIEWER;
 
 export default function UserFormPage({ mode }) {
   const isEdit = mode === 'edit';
   const { userId } = useParams();
   const navigate = useNavigate();
-  const [form, setForm] = useState({ name: '', email: '', role: ROLES[0], password: '' });
+  const [form, setForm] = useState({
+    name: '',
+    email: '',
+    role: ROLE_OPTIONS.includes(DEFAULT_ROLE) ? DEFAULT_ROLE : ROLE_OPTIONS[0],
+    password: ''
+  });
   const [loading, setLoading] = useState(isEdit);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
@@ -28,7 +35,12 @@ export default function UserFormPage({ mode }) {
         if (cancelled) {
           return;
         }
-        setForm({ name: data?.name ?? '', email: data?.email ?? '', role: data?.role ?? ROLES[0], password: '' });
+        setForm({
+          name: data?.name ?? '',
+          email: data?.email ?? '',
+          role: data?.role && ROLE_OPTIONS.includes(data.role) ? data.role : DEFAULT_ROLE,
+          password: ''
+        });
         setError(null);
       } catch (err) {
         if (!cancelled) {
@@ -142,7 +154,7 @@ export default function UserFormPage({ mode }) {
               Role
             </label>
             <select id="role" name="role" className={ui.formControl} value={form.role} onChange={handleChange}>
-              {ROLES.map((role) => (
+              {ROLE_OPTIONS.map((role) => (
                 <option key={role} value={role}>
                   {role}
                 </option>

--- a/data/users.js
+++ b/data/users.js
@@ -1,4 +1,5 @@
 import { resolveInsertedId } from './utils.js';
+import { ROLE_NONE } from '../shared/roles.js';
 
 /** @typedef {import('../server/types.js').Knex} Knex */
 /** @typedef {import('../server/types.js').User} User */
@@ -27,7 +28,7 @@ export function createUsersRepository(db) {
       id: row.id,
       name: row.Name,
       email: row.Email,
-      role: row.Role
+      role: row.Role ?? ROLE_NONE
     };
 
     if (includePassword) {

--- a/routes/api/auth.js
+++ b/routes/api/auth.js
@@ -3,6 +3,7 @@ import bcrypt from 'bcrypt';
 import rateLimit from 'express-rate-limit';
 
 import { ServiceError } from '../../services/errors.js';
+import { ROLE_NONE } from '../../shared/roles.js';
 
 /** @typedef {import('../../server/types.js').ServerContext} ServerContext */
 /** @typedef {import('../../server/types.js').RequestSession} RequestSession */
@@ -112,7 +113,7 @@ export function createAuthApi(context) {
         name: String(name).trim(),
         email: normalizedEmail,
         passwordHash,
-        role: 'User'
+        role: ROLE_NONE
       });
 
       if (!created) {

--- a/routes/api/groups.js
+++ b/routes/api/groups.js
@@ -1,7 +1,8 @@
 import { Router } from 'express';
 import { z } from 'zod';
 
-import { assertSessionAdmin } from '../../server/session.js';
+import { assertSessionRole } from '../../server/session.js';
+import { ROLE_ADMIN, ROLE_MANAGER } from '../../shared/roles.js';
 import { validateRequest } from '../middleware/validation.js';
 import { handleRouteError, sendError } from './utils.js';
 
@@ -15,7 +16,7 @@ export function createGroupsApi(context) {
 
   router.get('/', async (req, res) => {
     try {
-      assertSessionAdmin(req.session);
+      assertSessionRole(req.session, [ROLE_ADMIN, ROLE_MANAGER]);
       const groups = await groupRepository.listGroups();
       res.json({ status: 'success', data: groups });
     } catch (err) {
@@ -28,7 +29,7 @@ export function createGroupsApi(context) {
     validateRequest({ body: groupPayloadSchema }),
     async (req, res) => {
       try {
-        assertSessionAdmin(req.session);
+        assertSessionRole(req.session, [ROLE_ADMIN, ROLE_MANAGER]);
         const payload = req.validated.body;
 
         const created = await groupRepository.createGroup(payload);
@@ -44,7 +45,7 @@ export function createGroupsApi(context) {
     validateRequest({ params: groupIdParamsSchema }),
     async (req, res) => {
       try {
-        assertSessionAdmin(req.session);
+        assertSessionRole(req.session, [ROLE_ADMIN, ROLE_MANAGER]);
         const { id } = req.validated.params;
 
         const group = await groupRepository.getGroupById(id);
@@ -65,7 +66,7 @@ export function createGroupsApi(context) {
     validateRequest({ params: groupIdParamsSchema, body: groupPayloadSchema }),
     async (req, res) => {
       try {
-        assertSessionAdmin(req.session);
+        assertSessionRole(req.session, [ROLE_ADMIN, ROLE_MANAGER]);
         const { id } = req.validated.params;
         const payload = req.validated.body;
 
@@ -87,7 +88,7 @@ export function createGroupsApi(context) {
     validateRequest({ params: groupIdParamsSchema }),
     async (req, res) => {
       try {
-        assertSessionAdmin(req.session);
+        assertSessionRole(req.session, [ROLE_ADMIN, ROLE_MANAGER]);
         const { id } = req.validated.params;
 
         const existing = await groupRepository.getGroupById(id);

--- a/routes/api/hosts.js
+++ b/routes/api/hosts.js
@@ -1,7 +1,8 @@
 import { Router } from 'express';
 import { z } from 'zod';
 
-import { assertSessionAdmin } from '../../server/session.js';
+import { assertSessionRole } from '../../server/session.js';
+import { ROLE_ADMIN, ROLE_MANAGER } from '../../shared/roles.js';
 import { validateRequest } from '../middleware/validation.js';
 import { handleRouteError, sendError } from './utils.js';
 
@@ -16,7 +17,7 @@ export function createHostsApi(context) {
 
   router.get('/', async (req, res) => {
     try {
-      assertSessionAdmin(req.session);
+      assertSessionRole(req.session, [ROLE_ADMIN, ROLE_MANAGER]);
       const hosts = await hostRepository.listHosts();
       res.json({ status: 'success', data: hosts });
     } catch (err) {
@@ -29,7 +30,7 @@ export function createHostsApi(context) {
     validateRequest({ body: hostPayloadSchema }),
     async (req, res) => {
       try {
-        assertSessionAdmin(req.session);
+        assertSessionRole(req.session, [ROLE_ADMIN, ROLE_MANAGER]);
         const payload = req.validated.body;
 
         const created = await hostRepository.createHost(payload);
@@ -46,7 +47,7 @@ export function createHostsApi(context) {
     validateRequest({ params: hostIdParamsSchema }),
     async (req, res) => {
       try {
-        assertSessionAdmin(req.session);
+        assertSessionRole(req.session, [ROLE_ADMIN, ROLE_MANAGER]);
         const { id } = req.validated.params;
 
         const host = await hostRepository.getHostById(id);
@@ -67,7 +68,7 @@ export function createHostsApi(context) {
     validateRequest({ params: hostIdParamsSchema, body: hostPayloadSchema }),
     async (req, res) => {
       try {
-        assertSessionAdmin(req.session);
+        assertSessionRole(req.session, [ROLE_ADMIN, ROLE_MANAGER]);
         const { id } = req.validated.params;
         const payload = req.validated.body;
 
@@ -90,7 +91,7 @@ export function createHostsApi(context) {
     validateRequest({ params: hostIdParamsSchema }),
     async (req, res) => {
       try {
-        assertSessionAdmin(req.session);
+        assertSessionRole(req.session, [ROLE_ADMIN, ROLE_MANAGER]);
         const { id } = req.validated.params;
 
         const existing = await hostRepository.getHostById(id);

--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -3,6 +3,7 @@ import bcrypt from 'bcrypt';
 import { z } from 'zod';
 
 import { assertSessionAdmin } from '../../server/session.js';
+import { ALL_ROLES } from '../../shared/roles.js';
 import { validateRequest } from '../middleware/validation.js';
 import { handleRouteError, sendError } from './utils.js';
 
@@ -120,17 +121,19 @@ export function createUsersApi(context) {
   return router;
 }
 
+const roleSchema = requiredTrimmedString('Role').refine((value) => ALL_ROLES.includes(value), 'Invalid role.');
+
 const userCreateSchema = z.object({
   name: requiredTrimmedString('Name'),
   email: requiredTrimmedString('Email'),
-  role: requiredTrimmedString('Role'),
+  role: roleSchema,
   password: requiredTrimmedString('Password')
 });
 
 const userUpdateSchema = z.object({
   name: requiredTrimmedString('Name'),
   email: requiredTrimmedString('Email'),
-  role: requiredTrimmedString('Role'),
+  role: roleSchema,
   password: requiredTrimmedString('Password').optional()
 });
 

--- a/shared/roles.js
+++ b/shared/roles.js
@@ -1,0 +1,33 @@
+export const ROLE_ADMIN = 'Admin';
+export const ROLE_MANAGER = 'Manager';
+export const ROLE_VIEWER = 'Viewer';
+export const ROLE_NONE = 'None';
+
+export const ALL_ROLES = [ROLE_ADMIN, ROLE_MANAGER, ROLE_VIEWER, ROLE_NONE];
+export const ACTIVE_ROLES = [ROLE_ADMIN, ROLE_MANAGER, ROLE_VIEWER];
+
+/**
+ * Determines whether a user object has at least one of the permitted roles.
+ *
+ * @param {{ role?: string | null } | null | undefined} user
+ * @param {string[]} roles
+ * @returns {boolean}
+ */
+export function userHasRole(user, roles) {
+  if (!user || !Array.isArray(roles) || roles.length === 0) {
+    return false;
+  }
+
+  const role = typeof user.role === 'string' ? user.role : ROLE_NONE;
+  return roles.includes(role);
+}
+
+/**
+ * Returns the effective role for a user, falling back to {@link ROLE_NONE}.
+ *
+ * @param {{ role?: string | null } | null | undefined} user
+ * @returns {string}
+ */
+export function resolveUserRole(user) {
+  return typeof user?.role === 'string' ? user.role : ROLE_NONE;
+}


### PR DESCRIPTION
## Summary
- add shared role constants and enforce role tiers for API and session helpers
- update client routing and navigation for admin, manager, viewer, and pending users
- add request-access page and refresh tests to cover new permissions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5be0a97c4832e96062959d13f72e0