### PR TITLE
Add trust proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ The Nodervisor server listens on port `3000` by default. To expose it securely b
 
 After reloading, Apache serves Nodervisor via HTTPS while forwarding requests to the Node.js server on port `3000`. Remember to keep your certificates renewed (Certbot installs a systemd timer by default) and adjust firewall rules to allow traffic on ports 80 and 443.
 
+#### Configure Nodervisor to trust the proxy
+
+When Nodervisor runs behind a reverse proxy it must trust the forwarded headers in order to detect HTTPS sessions and set secure cookies correctly. Configure this by setting the `TRUST_PROXY` environment variable before starting the server:
+
+```
+TRUST_PROXY=1
+```
+
+The value `1` tells Express to trust the first proxy hop, which is appropriate when Apache or Nginx is the only proxy in front of Nodervisor. If your traffic flows through multiple proxies (for example, a load balancer in front of Nginx), set `TRUST_PROXY` to the number of hops or use `TRUST_PROXY=true` to trust all proxies. Leave the variable unset (or set it to `false`) when clients connect directly without a reverse proxy.
+
 ### Styling the dashboard
 
 The React dashboard is bundled with Vite and no longer relies on the legacy assets that previously lived under `public/css`. Styling is split into a small design system and component-scoped CSS modules:

--- a/server/app.js
+++ b/server/app.js
@@ -33,6 +33,7 @@ export function createApp(context) {
   app.set('port', config.port);
   app.set('host', config.host);
   app.set('env', config.env);
+  app.set('trust proxy', config.trustProxy ?? false);
 
   app.use(favicon(path.join(projectRoot, 'public', 'favicon.ico')));
   app.use(morgan('dev'));


### PR DESCRIPTION
## Summary
- allow configuring Express trust proxy via a TRUST_PROXY environment variable
- propagate the parsed trust proxy value to the app configuration and Express app
- document how to set TRUST_PROXY when running Nodervisor behind Apache or Nginx reverse proxies

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5c1d41bbc832e994441969f3ebd67