### PR TITLE
Ensure graceful shutdown and add integration test

### DIFF
--- a/__tests__/server/shutdown.test.js
+++ b/__tests__/server/shutdown.test.js
@@ -1,0 +1,83 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Knex from 'knex';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('server shutdown integration', () => {
+  /** @type {import('../../server/index.js')} */
+  let serverModule;
+  /** @type {string} */
+  let tempDir;
+
+  beforeAll(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nodervisor-shutdown-'));
+    const databasePath = path.join(tempDir, 'application.sqlite');
+    const sessionDatabasePath = path.join(tempDir, 'sessions.sqlite');
+
+    process.env.NODE_ENV = 'test';
+    process.env.DB_CLIENT = 'sqlite3';
+    process.env.DB_FILENAME = databasePath;
+    process.env.SESSION_DB_CLIENT = 'sqlite3';
+    process.env.SESSION_DB_FILENAME = sessionDatabasePath;
+    process.env.SESSION_SECRET = 'integration-secret';
+
+    jest.resetModules();
+
+    const { default: config } = await import('../../config.js');
+    const migrationDb = Knex(config.db);
+    await migrationDb.migrate.latest({
+      directory: path.resolve(__dirname, '../../migrations'),
+      loadExtensions: ['.cjs']
+    });
+    await migrationDb.destroy();
+
+    const sessionDb = Knex(config.sessionstore);
+    await sessionDb.destroy();
+
+    serverModule = await import('../../server/index.js');
+  });
+
+  afterAll(async () => {
+    if (serverModule?.shutdown) {
+      await serverModule.shutdown();
+    }
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+    delete process.env.DB_CLIENT;
+    delete process.env.DB_FILENAME;
+    delete process.env.SESSION_DB_CLIENT;
+    delete process.env.SESSION_DB_FILENAME;
+    delete process.env.SESSION_SECRET;
+  });
+
+  it('closes knex pools after shutdown', async () => {
+    const { start, shutdown } = serverModule;
+    let started;
+    try {
+      started = await start();
+      const { app, context, shutdown: stop } = started;
+
+      await request(app).get('/').expect(302);
+
+      await stop();
+
+      const dbPoolActive = context.db?.client?.pool?.numUsed?.() ?? 0;
+      const sessionPoolActive = context.sessionStore?.knex?.client?.pool?.numUsed?.() ?? 0;
+
+      expect(dbPoolActive).toBe(0);
+      expect(sessionPoolActive).toBe(0);
+    } finally {
+      if (started) {
+        await shutdown();
+      }
+    }
+  });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,5 @@
+import { pathToFileURL } from 'node:url';
+
 import Knex from 'knex';
 import { ConnectSessionKnexStore } from 'connect-session-knex';
 import supervisordapi from 'supervisord';
@@ -23,43 +25,194 @@ const context = createServerContext({
 
 const app = createApp(context);
 
-async function start() {
-  try {
+const refreshSignals = ['SIGHUP', 'SIGUSR2'];
+const registeredSignalHandlers = new Map();
+
+let stopHostRefresh = null;
+let serverInstance = null;
+let startPromise = null;
+let shutdownPromise = null;
+
+export async function start() {
+  if (startPromise) {
+    return startPromise;
+  }
+
+  startPromise = (async () => {
     await context.config.warmHosts(context.db);
 
-    const stopHostRefresh = context.config.scheduleHostRefresh(context.db, { logger: console });
-    const refreshSignals = ['SIGHUP', 'SIGUSR2'];
+    stopHostRefresh = context.config.scheduleHostRefresh(context.db, { logger: console });
 
-    const handleRefreshSignal = async (signal) => {
-      try {
-        await context.config.refreshHosts(context.db);
-        console.log(`Host cache refreshed after ${signal}`);
-      } catch (refreshErr) {
-        console.error(`Failed to refresh host cache after ${signal}`, refreshErr);
-      }
-    };
+    serverInstance = await new Promise((resolve, reject) => {
+      const server = app.listen(app.get('port'), app.get('host'));
+      server.once('listening', () => {
+        console.log(`Nodervisor launched on ${app.get('host')}:${app.get('port')}`);
+        resolve(server);
+      });
+      server.once('error', (err) => {
+        reject(err);
+      });
+    });
 
     refreshSignals.forEach((signal) => {
-      process.on(signal, handleRefreshSignal);
+      registerSignalHandler(signal, async (receivedSignal) => {
+        await context.config.refreshHosts(context.db);
+        console.log(`Host cache refreshed after ${receivedSignal}`);
+      });
     });
 
-    const server = app.listen(app.get('port'), app.get('host'), () => {
-      console.log(`Nodervisor launched on ${app.get('host')}:${app.get('port')}`);
+    registerSignalHandler('SIGINT', async (signal) => {
+      await shutdown({ signal });
+      if (process.exitCode === undefined) {
+        process.exitCode = 0;
+      }
     });
 
-    const shutdown = () => {
-      stopHostRefresh();
-      server.close(() => process.exit(0));
-    };
+    registerSignalHandler('SIGTERM', async (signal) => {
+      await shutdown({ signal });
+      if (process.exitCode === undefined) {
+        process.exitCode = 0;
+      }
+    });
 
-    process.once('SIGINT', shutdown);
-    process.once('SIGTERM', shutdown);
+    return { app, context, server: serverInstance, shutdown: () => shutdown({}) };
+  })();
+
+  try {
+    return await startPromise;
   } catch (err) {
-    console.error('Failed to start Nodervisor', err);
-    process.exit(1);
+    unregisterSignalHandlers();
+    if (typeof stopHostRefresh === 'function') {
+      try {
+        stopHostRefresh();
+      } catch (stopErr) {
+        console.error('Failed to stop host refresh timer', stopErr);
+      }
+      stopHostRefresh = null;
+    }
+    startPromise = null;
+    throw err;
   }
 }
 
-start();
+export async function shutdown({ signal } = {}) {
+  if (shutdownPromise) {
+    return shutdownPromise;
+  }
+
+  shutdownPromise = (async () => {
+    if (signal) {
+      console.log(`Received ${signal}, shutting down Nodervisor`);
+    }
+
+    unregisterSignalHandlers();
+
+    if (typeof stopHostRefresh === 'function') {
+      try {
+        stopHostRefresh();
+      } catch (err) {
+        console.error('Failed to stop host refresh timer', err);
+      }
+      stopHostRefresh = null;
+    }
+
+    const tasks = [
+      { label: 'HTTP server', run: () => closeServer(serverInstance) },
+      { label: 'database connection', run: () => context.db?.destroy?.() }
+    ];
+
+    if (typeof knexsessions?.destroy === 'function') {
+      tasks.push({ label: 'session database connection', run: () => knexsessions.destroy() });
+    }
+
+    if (typeof sessionStore.close === 'function') {
+      tasks.push({ label: 'session store', run: () => sessionStore.close() });
+    }
+
+    const results = await Promise.allSettled(tasks.map((task) => task.run()));
+
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        console.error(`Failed to close ${tasks[index].label}`, result.reason);
+      }
+    });
+
+    serverInstance = null;
+    startPromise = null;
+
+    return results;
+  })();
+
+  try {
+    return await shutdownPromise;
+  } finally {
+    shutdownPromise = null;
+  }
+}
+
+function createAsyncSignalHandler(handler) {
+  return async (signal) => {
+    try {
+      await handler(signal);
+    } catch (err) {
+      console.error(`Failed to handle ${signal}`, err);
+    }
+  };
+}
+
+function registerSignalHandler(signal, handler) {
+  const wrapped = createAsyncSignalHandler(handler);
+  let handlers = registeredSignalHandlers.get(signal);
+  if (!handlers) {
+    handlers = new Set();
+    registeredSignalHandlers.set(signal, handlers);
+  }
+  handlers.add(wrapped);
+  process.on(signal, wrapped);
+}
+
+function unregisterSignalHandlers() {
+  for (const [signal, handlers] of registeredSignalHandlers.entries()) {
+    for (const handler of handlers) {
+      process.off(signal, handler);
+    }
+  }
+  registeredSignalHandlers.clear();
+}
+
+function closeServer(server) {
+  if (!server) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    server.close((err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function isMainEntry() {
+  if (!process.argv[1]) {
+    return false;
+  }
+
+  try {
+    return import.meta.url === pathToFileURL(process.argv[1]).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isMainEntry()) {
+  start().catch((err) => {
+    console.error('Failed to start Nodervisor', err);
+    process.exitCode = 1;
+  });
+}
 
 export default app;


### PR DESCRIPTION
## Summary
- refactor the server bootstrap to await shutdown tasks, reuse async signal handling, and avoid direct process exits
- export the startup helpers so tests can drive the shutdown path and clean up database/session pools
- add an integration test that boots the server, exercises the shutdown flow, and verifies both knex pools report no active connections afterward

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5c1f5b448832ea46e81ab23fac4e4