### PR TITLE
Parse numeric TRUST_PROXY strings as integers

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ When Nodervisor runs behind a reverse proxy it must trust the forwarded headers 
 TRUST_PROXY=1
 ```
 
-The value `1` tells Express to trust the first proxy hop, which is appropriate when Apache or Nginx is the only proxy in front of Nodervisor. If your traffic flows through multiple proxies (for example, a load balancer in front of Nginx), set `TRUST_PROXY` to the number of hops or use `TRUST_PROXY=true` to trust all proxies. Leave the variable unset (or set it to `false`) when clients connect directly without a reverse proxy.
+The value `1` tells Express to trust the first proxy hop, which is appropriate when Apache or Nginx is the only proxy in front of Nodervisor. If your traffic flows through multiple proxies (for example, a load balancer in front of Nginx), set `TRUST_PROXY` to the number of hops (any non-negative integer works) or use a textual boolean such as `TRUST_PROXY=true` or `TRUST_PROXY=on` to trust all proxies. Leave the variable unset (or set it to `false`, `no`, or `off`) when clients connect directly without a reverse proxy.
 
 ### Styling the dashboard
 

--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -1,0 +1,31 @@
+import { beforeEach, afterAll, describe, expect, it, jest } from '@jest/globals';
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe('config trust proxy parsing', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.TRUST_PROXY;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('parses numeric strings as integers', async () => {
+    process.env.TRUST_PROXY = '1';
+
+    const { default: config } = await import('../config.js');
+
+    expect(config.trustProxy).toBe(1);
+  });
+
+  it('keeps textual booleans working', async () => {
+    process.env.TRUST_PROXY = 'true';
+
+    const { default: config } = await import('../config.js');
+
+    expect(config.trustProxy).toBe(true);
+  });
+});

--- a/config.js
+++ b/config.js
@@ -85,18 +85,18 @@ function trustProxyLike() {
         return undefined;
       }
 
+      const parsedNumber = Number(normalized);
+      if (Number.isInteger(parsedNumber) && parsedNumber >= 0) {
+        return parsedNumber;
+      }
+
       const lower = normalized.toLowerCase();
-      if (['true', '1', 'yes', 'y', 'on'].includes(lower)) {
+      if (['true', 'yes', 'y', 'on'].includes(lower)) {
         return true;
       }
 
-      if (['false', '0', 'no', 'n', 'off'].includes(lower)) {
+      if (['false', 'no', 'n', 'off'].includes(lower)) {
         return false;
-      }
-
-      const parsed = Number(normalized);
-      if (Number.isInteger(parsed) && parsed >= 0) {
-        return parsed;
       }
 
       ctx.addIssue({


### PR DESCRIPTION
## Summary
- parse numeric TRUST_PROXY strings as integers before falling back to boolean keywords
- add unit tests covering numeric string and textual boolean TRUST_PROXY values
- update README guidance about TRUST_PROXY configuration to mention numeric counts and textual booleans

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5c5d0dfc0832eb441dbbadbc9f1e2