### PR TITLE
Enforce strong password validation across auth flows

### DIFF
--- a/__tests__/shared/passwordPolicy.test.js
+++ b/__tests__/shared/passwordPolicy.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  PASSWORD_MIN_LENGTH,
+  checkPasswordAgainstPolicy,
+  isPasswordCompliant
+} from '../../shared/passwordPolicy.js';
+
+describe('password policy helpers', () => {
+  it('identifies weak passwords and reports the first error', () => {
+    const errors = checkPasswordAgainstPolicy('weakpass');
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toMatch(new RegExp(`${PASSWORD_MIN_LENGTH}`));
+    expect(isPasswordCompliant('weakpass')).toBe(false);
+  });
+
+  it('accepts passwords that meet every requirement', () => {
+    const password = 'ValidPass123!';
+
+    expect(checkPasswordAgainstPolicy(password)).toEqual([]);
+    expect(isPasswordCompliant(password)).toBe(true);
+  });
+});

--- a/shared/passwordPolicy.js
+++ b/shared/passwordPolicy.js
@@ -1,0 +1,47 @@
+export const PASSWORD_MIN_LENGTH = 12;
+const UPPERCASE_REGEX = /[A-Z]/;
+const LOWERCASE_REGEX = /[a-z]/;
+const NUMBER_REGEX = /[0-9]/;
+const SPECIAL_REGEX = /[^A-Za-z0-9]/;
+
+export const PASSWORD_POLICY_SUMMARY =
+  `Password must be at least ${PASSWORD_MIN_LENGTH} characters long and include uppercase, lowercase, number, and special character.`;
+
+/**
+ * Validates the provided password against the project's password policy.
+ *
+ * @param {unknown} password
+ * @returns {string[]} An array of validation error messages. Empty when the password complies.
+ */
+export function checkPasswordAgainstPolicy(password) {
+  const value = typeof password === 'string' ? password : String(password ?? '');
+  const errors = [];
+
+  if (value.length < PASSWORD_MIN_LENGTH) {
+    errors.push(`Password must be at least ${PASSWORD_MIN_LENGTH} characters long.`);
+  }
+  if (!UPPERCASE_REGEX.test(value)) {
+    errors.push('Password must include at least one uppercase letter.');
+  }
+  if (!LOWERCASE_REGEX.test(value)) {
+    errors.push('Password must include at least one lowercase letter.');
+  }
+  if (!NUMBER_REGEX.test(value)) {
+    errors.push('Password must include at least one digit.');
+  }
+  if (!SPECIAL_REGEX.test(value)) {
+    errors.push('Password must include at least one special character.');
+  }
+
+  return errors;
+}
+
+/**
+ * Determines whether the provided password complies with the policy.
+ *
+ * @param {unknown} password
+ * @returns {boolean}
+ */
+export function isPasswordCompliant(password) {
+  return checkPasswordAgainstPolicy(password).length === 0;
+}


### PR DESCRIPTION
## Summary
- add shared password policy helpers and require compliant credentials in the auth and users APIs via `validateRequest`
- surface inline password-strength feedback on the registration and user-management forms in the dashboard
- expand unit coverage for the new validators and password policy and update integration tests to use strong test credentials

## Testing
- `npm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68d5e2dcfd58832e8de965a47c4b541e