### PR TITLE
Disable self-registration by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ A Supervisord manager in node.js. Nodervisor provides a real-time web dashboard 
         # or provide a hash instead of plain text
         # ADMIN_SEED_PASSWORD_HASH=$2b$12$...
 
-     To disable public account creation, set `AUTH_ALLOW_SELF_REGISTRATION=false`. Leaving the flag enabled allows anyone who
-     can reach the login screen to create a low-privilege account, which may still reveal operational details such as host
-     names and process states.
+    Self-registration is disabled by default so new accounts must be created by an administrator. If you want to allow
+    visitors to sign up for low-privilege accounts, set `AUTH_ALLOW_SELF_REGISTRATION=true`. Be mindful that doing so can
+    expose operational details—such as host names and process states—to anyone who can reach the login screen.
 
   3. Run the database migrations and seed data:
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -42,7 +42,7 @@ import {
 export const SessionContext = createContext({
   user: null,
   status: 'loading',
-  allowSelfRegistration: true,
+  allowSelfRegistration: false,
   login: async () => {},
   logout: async () => {},
   register: async () => {},
@@ -58,7 +58,7 @@ function SessionProvider({ initialState, children }) {
   const [user, setUser] = useState(initialState?.user ?? null);
   const [status, setStatus] = useState(initialState?.user ? 'authenticated' : 'loading');
   const [allowSelfRegistration, setAllowSelfRegistration] = useState(
-    initialState?.auth?.allowSelfRegistration ?? true
+    initialState?.auth?.allowSelfRegistration ?? false
   );
   const initialFetchCompleted = useRef(Boolean(initialState?.user));
 

--- a/config.js
+++ b/config.js
@@ -173,7 +173,7 @@ const sessionCookieDomain = parsedEnv.SESSION_COOKIE_DOMAIN;
 const sessionCookieName = parsedEnv.SESSION_COOKIE_NAME ?? 'nv.sid';
 
 const trustProxy = parsedEnv.TRUST_PROXY;
-const authAllowSelfRegistration = parsedEnv.AUTH_ALLOW_SELF_REGISTRATION ?? true;
+const authAllowSelfRegistration = parsedEnv.AUTH_ALLOW_SELF_REGISTRATION ?? false;
 
 const defaultDbFilename = path.join(projectRoot, 'nodervisor.sqlite');
 const dbClient = parsedEnv.DB_CLIENT ?? 'sqlite3';

--- a/routes/api/auth.js
+++ b/routes/api/auth.js
@@ -19,7 +19,7 @@ export function createAuthApi(context) {
   } = context;
   const sessionCookieName = config?.session?.name ?? 'connect.sid';
   const sessionCookieConfig = config?.session?.cookie;
-  const isRegistrationAllowed = () => Boolean(config?.auth?.allowSelfRegistration ?? true);
+  const isRegistrationAllowed = () => Boolean(config?.auth?.allowSelfRegistration ?? false);
 
   const loginLimiter = rateLimit({
     windowMs: 60 * 1000,

--- a/server/renderAppPage.js
+++ b/server/renderAppPage.js
@@ -19,7 +19,7 @@ export function renderAppPage({
   const cssAssets = [...(dashboardAssets?.css ?? [])];
 
   const scriptAssets = dashboardAssets?.js ? [dashboardAssets.js] : [];
-  const allowSelfRegistration = Boolean(auth?.allowSelfRegistration ?? true);
+  const allowSelfRegistration = Boolean(auth?.allowSelfRegistration ?? false);
   const serializedState = serializeState({
     user: session?.user ?? null,
     auth: {


### PR DESCRIPTION
## Summary
- default the AUTH_ALLOW_SELF_REGISTRATION flag to false across the server and client
- ensure the dashboard initial state honors the disabled default and update docs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5f52d9044832e8fe9107b236dd449