### PR TITLE
Escape line separators in serialized app state

### DIFF
--- a/__tests__/server/renderAppPage.test.js
+++ b/__tests__/server/renderAppPage.test.js
@@ -1,0 +1,47 @@
+import { renderAppPage } from '../../server/renderAppPage.js';
+
+describe('renderAppPage', () => {
+  it('escapes serialized state before embedding in HTML', () => {
+    const stateWithSeparators = {
+      session: {
+        user: {
+          name: 'before\u2028middle\u2029after',
+          note: 'Contains </script and <!-- sequences'
+        }
+      }
+    };
+
+    const html = renderAppPage(stateWithSeparators);
+    const scriptMatch = html.match(
+      /<script id="app-state" type="application\/json">([^<]*)<\/script>/
+    );
+
+    expect(scriptMatch).not.toBeNull();
+
+    const serializedState = scriptMatch?.[1] ?? '';
+
+    expect(serializedState).toContain('\\u2028');
+    expect(serializedState).toContain('\\u2029');
+    expect(serializedState).toContain('\\u003c\\/script');
+    expect(serializedState).toContain('\\u003c!--');
+
+    expect(serializedState).not.toContain('\u2028');
+    expect(serializedState).not.toContain('\u2029');
+    expect(serializedState).not.toContain('</script');
+    expect(serializedState).not.toContain('<!--');
+
+    expect(JSON.parse(serializedState)).toEqual({
+      user: {
+        name: 'before\u2028middle\u2029after',
+        note: 'Contains </script and <!-- sequences'
+      },
+      auth: {
+        session: '/api/auth/session',
+        login: '/api/auth/login',
+        logout: '/api/auth/logout',
+        register: '/api/auth/register',
+        allowSelfRegistration: false
+      }
+    });
+  });
+});

--- a/server/renderAppPage.js
+++ b/server/renderAppPage.js
@@ -58,7 +58,14 @@ export function renderAppPage({
 }
 
 function serializeState(value) {
-  return JSON.stringify(value).replace(/</g, '\\u003c');
+  const lineSeparatorPattern = new RegExp(String.fromCharCode(0x2028), 'g');
+  const paragraphSeparatorPattern = new RegExp(String.fromCharCode(0x2029), 'g');
+
+  return JSON.stringify(value)
+    .replace(/<\/script/gi, '<\\/script')
+    .replace(/</g, '\\u003c')
+    .replace(lineSeparatorPattern, '\\u2028')
+    .replace(paragraphSeparatorPattern, '\\u2029');
 }
 
 function escapeAttribute(value) {


### PR DESCRIPTION
## Summary
- harden the app state serializer to escape </script> tokens and Unicode line/paragraph separators before embedding HTML
- add a regression test to ensure the rendered HTML uses escaped separators and stays parseable

## Testing
- npm test -- __tests__/server/renderAppPage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d5fe7ebbb8832ea44a74283e1049a9