### PR TITLE
Relax login password validation

### DIFF
--- a/routes/api/auth.js
+++ b/routes/api/auth.js
@@ -198,9 +198,14 @@ const passwordSchema = z
     }
   });
 
+const loginPasswordSchema = z.preprocess(
+  (value) => (value === undefined ? value : String(value)),
+  z.string({ required_error: 'Password is required.' }).trim().min(1, 'Password is required.')
+);
+
 const loginRequestSchema = z.object({
   email: emailSchema.transform((value) => value.toLowerCase()),
-  password: passwordSchema
+  password: loginPasswordSchema
 });
 
 const registrationSchema = z.object({


### PR DESCRIPTION
## Summary
- add a relaxed password schema for login requests that accepts any non-empty trimmed string
- keep the strict registration validation while updating tests to confirm weak passwords can authenticate when bcrypt matches

## Testing
- npm test -- --runTestsByPath __tests__/routes/apiValidation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d615953894832ea1c3aa9b66dccaa8