### PR TITLE
Handle duplicate email error in auth registration

### DIFF
--- a/__tests__/routes/apiValidation.test.js
+++ b/__tests__/routes/apiValidation.test.js
@@ -8,6 +8,7 @@ import { createGroupsApi } from '../../routes/api/groups.js';
 import { createAuthApi } from '../../routes/api/auth.js';
 import { createUsersApi } from '../../routes/api/users.js';
 import { ROLE_ADMIN, ROLE_NONE, ROLE_VIEWER } from '../../shared/roles.js';
+import { EmailAlreadyExistsError } from '../../data/users.js';
 
 const STRONG_PASSWORD = 'ValidPass123!';
 
@@ -264,6 +265,26 @@ describe('API validation middleware', () => {
         role: ROLE_NONE,
         passwordHash: 'hashed-password'
       });
+      hashSpy.mockRestore();
+    });
+
+    it('returns a conflict error when registration encounters a duplicate email', async () => {
+      const hashSpy = jest.spyOn(bcrypt, 'hash').mockResolvedValue('hashed-password');
+      userRepository.findByEmail.mockResolvedValue(null);
+      userRepository.createUser.mockRejectedValue(new EmailAlreadyExistsError());
+
+      const response = await request(app).post('/auth/register').send({
+        name: 'Existing User',
+        email: 'duplicate@example.com',
+        password: STRONG_PASSWORD
+      });
+
+      expect(response.status).toBe(409);
+      expect(response.body).toEqual({
+        status: 'error',
+        error: { message: 'An account with that email already exists.' }
+      });
+      expect(userRepository.createUser).toHaveBeenCalled();
       hashSpy.mockRestore();
     });
   });

--- a/routes/api/auth.js
+++ b/routes/api/auth.js
@@ -4,6 +4,7 @@ import rateLimit from 'express-rate-limit';
 import { z } from 'zod';
 
 import { ServiceError } from '../../services/errors.js';
+import { EmailAlreadyExistsError } from '../../data/users.js';
 import { ROLE_NONE } from '../../shared/roles.js';
 import { checkPasswordAgainstPolicy } from '../../shared/passwordPolicy.js';
 import { validateRequest } from '../middleware/validation.js';
@@ -147,6 +148,13 @@ export function createAuthApi(context) {
 
         res.status(201).json({ status: 'success', data: { user: created } });
       } catch (err) {
+        if (err instanceof EmailAlreadyExistsError || err?.name === 'EmailAlreadyExistsError') {
+          res
+            .status(409)
+            .json({ status: 'error', error: { message: 'An account with that email already exists.' } });
+          return;
+        }
+
         handleError(res, err);
       }
     }


### PR DESCRIPTION
## Summary
- ensure the auth registration handler translates EmailAlreadyExistsError into the existing 409 response
- add a validation test that verifies duplicate email registration surfaces the conflict payload

## Testing
- npm test -- __tests__/routes/apiValidation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d615bda248832eb22e0585fe003a2e