### PR TITLE
Use node scheme for built-in modules

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import { dirname, resolve } from 'path';
-import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/server/app.js
+++ b/server/app.js
@@ -1,6 +1,6 @@
 import express from 'express';
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import favicon from 'serve-favicon';
 import morgan from 'morgan';
 import methodOverride from 'method-override';
@@ -9,7 +9,7 @@ import session from 'express-session';
 import errorhandler from 'errorhandler';
 import helmet from 'helmet';
 import csurf from 'csurf';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 import { createRouter } from '../routes/index.js';
 


### PR DESCRIPTION
## Summary
- update the server app to import built-in modules via the `node:` scheme
- adjust the Vite config to use `node:` specifiers for path and url

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6184523dc832e8d4d6658acbe375d