### PR TITLE
Switch server context to ESM JSON import

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -2,5 +2,8 @@ module.exports = {
   presets: [
     ['@babel/preset-env', { targets: { node: 'current' } }],
     ['@babel/preset-react', { runtime: 'automatic' }]
-  ]
+  ],
+  parserOpts: {
+    plugins: [['importAttributes', { deprecatedAssertSyntax: true }]]
+  }
 };

--- a/server/context.js
+++ b/server/context.js
@@ -1,15 +1,12 @@
-import { createRequire } from 'module';
 import { createGroupsRepository } from '../data/groups.js';
 import { createHostsRepository } from '../data/hosts.js';
 import { createUsersRepository } from '../data/users.js';
+import packageJson from '../package.json' assert { type: 'json' };
 
 /** @typedef {import('./types.js').ServerContext} ServerContext */
 /** @typedef {import('./types.js').ServerConfig} ServerConfig */
 /** @typedef {import('./types.js').Knex} Knex */
 /** @typedef {import('./types.js').SessionStore} SessionStore */
-
-const require = createRequire(import.meta.url);
-const packageJson = require('../package.json');
 
 /**
  * Creates an immutable context object used by the server and route layers.


### PR DESCRIPTION
## Summary
- switch the server context to load package.json via an ESM JSON import instead of createRequire
- update the Babel parser options to accept import attributes used by Jest

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6184f4614832e9036c02198d5be81