### PR TITLE
Enable linting for client React code

### DIFF
--- a/client/src/Dashboard.jsx
+++ b/client/src/Dashboard.jsx
@@ -278,7 +278,7 @@ function useDashboardData(pollInterval) {
           const payload = JSON.parse(event.data);
           applyRawHosts(payload);
           setError(null);
-        } catch (err) {
+        } catch (_err) {
           setError('Received malformed supervisor snapshot.');
         }
       });
@@ -288,7 +288,7 @@ function useDashboardData(pollInterval) {
           const payload = JSON.parse(event.data);
           applyUpdatePayload(payload);
           setError(null);
-        } catch (err) {
+        } catch (_err) {
           setError('Received malformed supervisor update.');
         }
       });

--- a/config/eslint/react-plugin.js
+++ b/config/eslint/react-plugin.js
@@ -1,0 +1,69 @@
+function markJSXNameAsUsed(context, node) {
+  if (!node) {
+    return;
+  }
+
+  switch (node.type) {
+    case 'JSXIdentifier':
+      context.sourceCode.markVariableAsUsed(node.name);
+      break;
+    case 'JSXMemberExpression':
+      markJSXNameAsUsed(context, node.object);
+      break;
+    case 'JSXNamespacedName':
+      markJSXNameAsUsed(context, node.namespace);
+      break;
+    default:
+      break;
+  }
+}
+
+const jsxUsesVarsRule = {
+  meta: {
+    docs: {
+      description: 'Marks variables used in JSX as used to support no-unused-vars.',
+      recommended: true
+    },
+    schema: []
+  },
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        markJSXNameAsUsed(context, node.name);
+      },
+      JSXClosingElement(node) {
+        markJSXNameAsUsed(context, node.name);
+      },
+      JSXAttribute(attribute) {
+        if (attribute.value && attribute.value.type === 'JSXExpressionContainer') {
+          const expression = attribute.value.expression;
+          if (expression?.type === 'Identifier') {
+            context.sourceCode.markVariableAsUsed(expression.name);
+          }
+        }
+      }
+    };
+  }
+};
+
+const reactPlugin = {
+  meta: {
+    name: 'eslint-plugin-react-stub',
+    version: '0.0.0'
+  },
+  configs: {
+    recommended: {
+      rules: {
+        'react/jsx-uses-vars': 'error'
+      }
+    },
+    'jsx-runtime': {
+      rules: {}
+    }
+  },
+  rules: {
+    'jsx-uses-vars': jsxUsesVarsRule
+  }
+};
+
+export default reactPlugin;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 import js from '@eslint/js';
 import prettier from 'eslint-config-prettier';
 import globals from 'globals';
+import reactPlugin from './config/eslint/react-plugin.js';
 
 const baseConfig = {
   files: ['**/*.js', '**/*.jsx'],
@@ -21,15 +22,50 @@ const baseConfig = {
   rules: {
     ...js.configs.recommended.rules,
     ...prettier.rules,
-    'no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }]
+    'no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrors: 'all',
+        caughtErrorsIgnorePattern: '^_'
+      }
+    ]
+  }
+};
+
+const reactRecommendedRules = {
+  ...(reactPlugin.configs?.recommended?.rules ?? {}),
+  ...(reactPlugin.configs?.['jsx-runtime']?.rules ?? {})
+};
+
+const clientLanguageOptions = {
+  ...baseConfig.languageOptions,
+  globals: {
+    ...globals.browser
   }
 };
 
 export default [
   {
-    ignores: ['node_modules/', 'public/', 'client/', '*.sqlite']
+    ignores: ['node_modules/', 'public/', '*.sqlite']
   },
   baseConfig,
+  {
+    files: ['client/**/*.{js,jsx}'],
+    languageOptions: clientLanguageOptions,
+    plugins: {
+      react: reactPlugin
+    },
+    settings: {
+      react: {
+        version: 'detect'
+      }
+    },
+    rules: {
+      ...reactRecommendedRules
+    }
+  },
   {
     files: ['**/__tests__/**/*.js', '**/__tests__/**/*.jsx'],
     languageOptions: {


### PR DESCRIPTION
## Summary
- remove the client directory from the global ESLint ignore list and add a browser/React configuration block for client JS/JSX files
- provide a minimal React ESLint plugin implementation so JSX usage marks variables as used and reuse its recommended rules
- relax the no-unused-vars rule to ignore underscore-prefixed catch parameters and update dashboard stream handlers accordingly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d61834d1cc832eb06d9b5f1097702b