### PR TITLE
Harden host URL handling

### DIFF
--- a/__tests__/client/adminPages.test.jsx
+++ b/__tests__/client/adminPages.test.jsx
@@ -35,6 +35,23 @@ describe('Admin pages', () => {
     expect(screen.getByRole('link', { name: /add host/i })).toHaveAttribute('href', '/hosts/new');
   });
 
+  it('renders unsafe host URLs as plain text', async () => {
+    requestJson.mockResolvedValueOnce([
+      { id: 2, name: 'Unsanitized', url: 'javascript:alert(1)', groupName: null }
+    ]);
+
+    render(
+      <MemoryRouter>
+        <HostsListPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(requestJson).toHaveBeenCalledWith('/api/v1/hosts'));
+
+    const urlCell = await screen.findByText('javascript:alert(1)');
+    expect(urlCell.closest('a')).toBeNull();
+  });
+
   it('submits a new host to the API', async () => {
     requestJson
       .mockResolvedValueOnce([]) // groups

--- a/__tests__/routes/apiValidation.test.js
+++ b/__tests__/routes/apiValidation.test.js
@@ -67,6 +67,19 @@ describe('API validation middleware', () => {
       expect(Array.isArray(response.body.error.details)).toBe(true);
       expect(hostRepository.createHost).not.toHaveBeenCalled();
     });
+
+    it('rejects URLs with unsafe protocols', async () => {
+      const response = await request(app)
+        .post('/hosts')
+        .send({ name: 'Malicious', url: 'javascript:alert(1)' });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        status: 'error',
+        error: expect.objectContaining({ message: 'URL must be a valid http(s) URL.' })
+      });
+      expect(hostRepository.createHost).not.toHaveBeenCalled();
+    });
   });
 
   describe('groups', () => {

--- a/client/src/pages/HostsListPage.jsx
+++ b/client/src/pages/HostsListPage.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 
 import { requestJson } from '../apiClient.js';
 import ui from '../styles/ui.module.css';
+import { isSafeUrl } from '../../../shared/url.js';
 
 export default function HostsListPage() {
   const [hosts, setHosts] = useState([]);
@@ -86,9 +87,13 @@ export default function HostsListPage() {
                 <tr key={host.id}>
                   <th scope="row">{host.name}</th>
                   <td>
-                    <a href={host.url} target="_blank" rel="noreferrer">
-                      {host.url}
-                    </a>
+                    {isSafeUrl(host.url) ? (
+                      <a href={host.url} target="_blank" rel="noreferrer">
+                        {host.url}
+                      </a>
+                    ) : (
+                      host.url || '—'
+                    )}
                   </td>
                   <td>{host.groupName ?? '—'}</td>
                   <td className={ui.tableCellNumeric}>

--- a/data/hosts.js
+++ b/data/hosts.js
@@ -1,3 +1,4 @@
+import { assertSafeUrl, normalizeSafeUrl } from '../shared/url.js';
 import { resolveInsertedId } from './utils.js';
 
 /** @typedef {import('../server/types.js').Knex} Knex */
@@ -21,10 +22,12 @@ export function createHostsRepository(db) {
       return null;
     }
 
+    const safeUrl = normalizeSafeUrl(row.Url);
+
     return {
       id: row.idHost,
       name: row.Name,
-      url: row.Url,
+      url: safeUrl ?? '',
       groupId: row.idGroup ?? null,
       groupName: row.GroupName ?? null
     };
@@ -87,10 +90,12 @@ export function createHostsRepository(db) {
      * @returns {Promise<Host | null>}
      */
     async createHost({ name, url, groupId = null }) {
+      const safeUrl = assertSafeUrl(url);
+
       return db.transaction(async (trx) => {
         const insertData = {
           Name: name,
-          Url: url,
+          Url: safeUrl,
           idGroup: groupId ?? null
         };
 
@@ -112,12 +117,14 @@ export function createHostsRepository(db) {
      * @returns {Promise<Host | null>}
      */
     async updateHost(id, { name, url, groupId = null }) {
+      const safeUrl = assertSafeUrl(url);
+
       return db.transaction(async (trx) => {
         await trx(TABLE)
           .where(ID_COLUMN, id)
           .update({
             Name: name,
-            Url: url,
+            Url: safeUrl,
             idGroup: groupId ?? null
           });
 

--- a/shared/url.js
+++ b/shared/url.js
@@ -1,0 +1,58 @@
+const SAFE_URL_PROTOCOLS = new Set(['http:', 'https:']);
+
+/**
+ * Normalizes the provided value into a safe http(s) URL string.
+ *
+ * @param {unknown} value
+ * @returns {string | null}
+ */
+export function normalizeSafeUrl(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (!SAFE_URL_PROTOCOLS.has(parsed.protocol)) {
+      return null;
+    }
+
+    return trimmed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Determines whether the provided value is a safe http(s) URL.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isSafeUrl(value) {
+  return normalizeSafeUrl(value) !== null;
+}
+
+/**
+ * Ensures that the provided value is a safe http(s) URL and returns the
+ * normalized string. Throws an error if the value is unsafe.
+ *
+ * @param {unknown} value
+ * @param {string} [message]
+ * @returns {string}
+ */
+export function assertSafeUrl(value, message = 'URL must be a valid http(s) URL.') {
+  const normalized = normalizeSafeUrl(value);
+  if (!normalized) {
+    throw new Error(message);
+  }
+
+  return normalized;
+}
+
+export const safeUrlProtocols = SAFE_URL_PROTOCOLS;


### PR DESCRIPTION
## Summary
- restrict host payload validation to http(s) URLs and normalize the stored value
- add shared URL safety helpers and apply them in the data layer and dashboard UI
- cover unsafe URL handling with backend validation and React rendering tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6192407d4832e9fdccd420a70274a