### PR TITLE
Clamp process stream polling intervals

### DIFF
--- a/__tests__/routes/supervisordErrors.test.js
+++ b/__tests__/routes/supervisordErrors.test.js
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import express from 'express';
 import request from 'supertest';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
@@ -15,28 +16,38 @@ const createLoggerMock = () => {
   return logger;
 };
 
+const MIN_INTERVAL = 1000;
+const MAX_INTERVAL = 60000;
+const DEFAULT_INTERVAL = 5000;
+
 describe('Supervisord route error sanitization', () => {
   let app;
   let mockFetchAll;
+  let mockCreateStream;
   let ServiceErrorClass;
+  let SupervisordServiceMock;
 
   beforeEach(async () => {
     jest.resetModules();
     mockFetchAll = jest.fn();
+    mockCreateStream = jest.fn(() => ({
+      on: jest.fn(),
+      close: jest.fn(),
+      removeAllListeners: jest.fn()
+    }));
 
-    const SupervisordServiceMock = jest.fn().mockImplementation(() => ({
+    SupervisordServiceMock = jest.fn().mockImplementation(() => ({
       fetchAllProcessInfo: mockFetchAll,
-      createProcessStream: jest.fn(() => ({
-        on: jest.fn(),
-        close: jest.fn(),
-        removeAllListeners: jest.fn()
-      })),
+      createProcessStream: mockCreateStream,
       controlProcess: jest.fn(),
       getProcessLog: jest.fn()
     }));
 
     jest.unstable_mockModule('../../services/supervisordService.js', () => ({
-      SupervisordService: SupervisordServiceMock
+      SupervisordService: SupervisordServiceMock,
+      MIN_PROCESS_STREAM_INTERVAL_MS: MIN_INTERVAL,
+      MAX_PROCESS_STREAM_INTERVAL_MS: MAX_INTERVAL,
+      DEFAULT_PROCESS_STREAM_INTERVAL_MS: DEFAULT_INTERVAL
     }));
 
     const { createRouter } = await import('../../routes/index.js');
@@ -99,5 +110,65 @@ describe('Supervisord route error sanitization', () => {
     expect(response.body.error.message).toBe('failure');
     expect(response.body.error.details.headers.Authorization).toBe('[REDACTED]');
     expect(JSON.stringify(response.body)).not.toContain('secret-token');
+  });
+
+  const getStreamRouteHandler = () => {
+    const layer = app._router.stack.find(
+      (entry) => entry.route?.path === '/api/v1/supervisors/stream'
+    );
+
+    if (!layer) {
+      throw new Error('Stream route not found');
+    }
+
+    return layer.route.stack[0].handle;
+  };
+
+  const createMockResponse = () => {
+    const res = {};
+    res.set = jest.fn();
+    res.flushHeaders = jest.fn();
+    res.write = jest.fn();
+    res.status = jest.fn(() => res);
+    res.json = jest.fn(() => res);
+    res.type = jest.fn(() => res);
+    res.send = jest.fn(() => res);
+    return res;
+  };
+
+  const createMockRequest = (interval) => {
+    const req = new EventEmitter();
+    req.query = interval === undefined ? {} : { interval };
+    req.session = { loggedIn: true, user: { role: ROLE_ADMIN } };
+    req.app = { locals: { dashboardAssets: {} } };
+    return req;
+  };
+
+  it('clamps stream intervals below the minimum', async () => {
+    const handler = getStreamRouteHandler();
+    const req = createMockRequest('10');
+    const res = createMockResponse();
+
+    await handler(req, res, jest.fn());
+
+    expect(mockCreateStream).toHaveBeenCalledWith(
+      expect.objectContaining({ intervalMs: MIN_INTERVAL })
+    );
+
+    req.emit('close');
+  });
+
+  it('clamps stream intervals above the maximum', async () => {
+    const handler = getStreamRouteHandler();
+    const req = createMockRequest(String(MAX_INTERVAL * 2));
+    const res = createMockResponse();
+
+    await handler(req, res, jest.fn());
+
+    expect(mockCreateStream).toHaveBeenCalledWith(
+      expect.objectContaining({ intervalMs: MAX_INTERVAL })
+    );
+
+    req.emit('close');
   });
 });

--- a/__tests__/services/supervisordService.stream.test.js
+++ b/__tests__/services/supervisordService.stream.test.js
@@ -1,0 +1,88 @@
+import { jest } from '@jest/globals';
+
+import {
+  SupervisordService,
+  DEFAULT_PROCESS_STREAM_INTERVAL_MS,
+  MAX_PROCESS_STREAM_INTERVAL_MS,
+  MIN_PROCESS_STREAM_INTERVAL_MS
+} from '../../services/supervisordService.js';
+
+const createLoggerMock = () => {
+  const logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  };
+  logger.child = jest.fn(() => logger);
+  return logger;
+};
+
+const createMetricsMock = () => ({
+  onRpcSuccess: jest.fn(),
+  onRpcFailure: jest.fn(),
+  onCircuitOpen: jest.fn(),
+  onCircuitClose: jest.fn()
+});
+
+describe('SupervisordService.createProcessStream interval bounds', () => {
+  let service;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    service = new SupervisordService({
+      config: { hosts: {} },
+      supervisordapi: { connect: jest.fn() },
+      logger: createLoggerMock(),
+      metrics: createMetricsMock()
+    });
+    service.fetchAllProcessInfo = jest.fn().mockResolvedValue({});
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (service?.fetchAllProcessInfo) {
+      service.fetchAllProcessInfo.mockReset();
+    }
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  const waitForInitialTick = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
+  it('enforces the minimum polling interval', async () => {
+    const stream = service.createProcessStream({ intervalMs: MIN_PROCESS_STREAM_INTERVAL_MS / 2 });
+
+    await waitForInitialTick();
+
+    expect(service.fetchAllProcessInfo).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), MIN_PROCESS_STREAM_INTERVAL_MS);
+
+    stream.close();
+  });
+
+  it('enforces the maximum polling interval', async () => {
+    const stream = service.createProcessStream({ intervalMs: MAX_PROCESS_STREAM_INTERVAL_MS * 2 });
+
+    await waitForInitialTick();
+
+    expect(service.fetchAllProcessInfo).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), MAX_PROCESS_STREAM_INTERVAL_MS);
+
+    stream.close();
+  });
+
+  it('uses the default interval for non-numeric values', async () => {
+    const stream = service.createProcessStream({ intervalMs: Number.NaN });
+
+    await waitForInitialTick();
+
+    expect(service.fetchAllProcessInfo).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), DEFAULT_PROCESS_STREAM_INTERVAL_MS);
+
+    stream.close();
+  });
+});


### PR DESCRIPTION
## Summary
- clamp the supervisor stream interval query parameter to predefined bounds before creating the stream
- enforce the minimum and maximum interval inside `SupervisordService.createProcessStream` and export shared constants
- extend route and service tests to verify interval coercion behavior

## Testing
- npm test -- --runTestsByPath __tests__/services/supervisordService.stream.test.js __tests__/routes/supervisordErrors.test.js *(fails: npm/node unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6192668f8832ebf7126346cd7298a