### PR TITLE
refactor: centralize zod schema helpers

### DIFF
--- a/routes/api/auth.js
+++ b/routes/api/auth.js
@@ -8,6 +8,7 @@ import { EmailAlreadyExistsError } from '../../data/users.js';
 import { ROLE_NONE } from '../../shared/roles.js';
 import { checkPasswordAgainstPolicy } from '../../shared/passwordPolicy.js';
 import { validateRequest } from '../middleware/validation.js';
+import { normalizedEmailSchema, requiredTrimmedString } from './schemaHelpers.js';
 
 /** @typedef {import('../../server/types.js').ServerContext} ServerContext */
 /** @typedef {import('../../server/types.js').RequestSession} RequestSession */
@@ -221,24 +222,3 @@ const registrationSchema = z.object({
   email: emailSchema.transform((value) => value.toLowerCase()),
   password: passwordSchema
 });
-
-function requiredTrimmedString(field) {
-  return z.preprocess(
-    (value) => (value === undefined ? value : String(value)),
-    z
-      .string({ required_error: `${field} is required.` })
-      .trim()
-      .min(1, `${field} is required.`)
-  );
-}
-
-function normalizedEmailSchema(field) {
-  return z.preprocess(
-    (value) => (value === undefined ? value : String(value)),
-    z
-      .string({ required_error: `${field} is required.` })
-      .trim()
-      .min(1, `${field} is required.`)
-      .email('Invalid email address.')
-  );
-}

--- a/routes/api/groups.js
+++ b/routes/api/groups.js
@@ -5,6 +5,7 @@ import { assertSessionRole } from '../../server/session.js';
 import { ROLE_ADMIN, ROLE_MANAGER } from '../../shared/roles.js';
 import { validateRequest } from '../middleware/validation.js';
 import { handleRouteError, sendError } from './utils.js';
+import { requiredTrimmedString } from './schemaHelpers.js';
 
 /** @typedef {import('../../server/types.js').ServerContext} ServerContext */
 
@@ -121,13 +122,3 @@ const groupIdParamsSchema = z.object({
     .number({ invalid_type_error: 'Invalid group id.' })
     .refine((value) => Number.isFinite(value), 'Invalid group id.')
 });
-
-function requiredTrimmedString(field) {
-  return z.preprocess(
-    (value) => (value === undefined ? value : String(value)),
-    z
-      .string({ required_error: `${field} is required.` })
-      .trim()
-      .min(1, `${field} is required.`)
-  );
-}

--- a/routes/api/hosts.js
+++ b/routes/api/hosts.js
@@ -6,6 +6,7 @@ import { ROLE_ADMIN, ROLE_MANAGER } from '../../shared/roles.js';
 import { isSafeUrl, normalizeSafeUrl } from '../../shared/url.js';
 import { validateRequest } from '../middleware/validation.js';
 import { handleRouteError, sendError } from './utils.js';
+import { requiredTrimmedString } from './schemaHelpers.js';
 
 /** @typedef {import('../../server/types.js').ServerContext} ServerContext */
 
@@ -148,16 +149,6 @@ function nullableNumber(message) {
 
       return Number(value);
     });
-}
-
-function requiredTrimmedString(field) {
-  return z.preprocess(
-    (value) => (value === undefined ? value : String(value)),
-    z
-      .string({ required_error: `${field} is required.` })
-      .trim()
-      .min(1, `${field} is required.`)
-  );
 }
 
 function requiredHttpUrl(field) {

--- a/routes/api/schemaHelpers.js
+++ b/routes/api/schemaHelpers.js
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export function requiredTrimmedString(field) {
+  return z.preprocess(
+    (value) => (value === undefined ? value : String(value)),
+    z
+      .string({ required_error: `${field} is required.` })
+      .trim()
+      .min(1, `${field} is required.`)
+  );
+}
+
+export function normalizedEmailSchema(field) {
+  return z.preprocess(
+    (value) => (value === undefined ? value : String(value)),
+    z
+      .string({ required_error: `${field} is required.` })
+      .trim()
+      .min(1, `${field} is required.`)
+      .email('Invalid email address.')
+  );
+}

--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -8,6 +8,7 @@ import { ALL_ROLES } from '../../shared/roles.js';
 import { checkPasswordAgainstPolicy } from '../../shared/passwordPolicy.js';
 import { validateRequest } from '../middleware/validation.js';
 import { handleRouteError, sendError } from './utils.js';
+import { normalizedEmailSchema, requiredTrimmedString } from './schemaHelpers.js';
 
 /** @typedef {import('../../server/types.js').ServerContext} ServerContext */
 
@@ -168,24 +169,3 @@ const userIdParamsSchema = z.object({
     .number({ invalid_type_error: 'Invalid user id.' })
     .refine((value) => Number.isFinite(value), 'Invalid user id.')
 });
-
-function requiredTrimmedString(field) {
-  return z.preprocess(
-    (value) => (value === undefined ? value : String(value)),
-    z
-      .string({ required_error: `${field} is required.` })
-      .trim()
-      .min(1, `${field} is required.`)
-  );
-}
-
-function normalizedEmailSchema(field) {
-  return z.preprocess(
-    (value) => (value === undefined ? value : String(value)),
-    z
-      .string({ required_error: `${field} is required.` })
-      .trim()
-      .min(1, `${field} is required.`)
-      .email('Invalid email address.')
-  );
-}


### PR DESCRIPTION
## Summary
- add a shared routes/api/schemaHelpers.js module that encapsulates reusable Zod builders
- update groups, hosts, users, and auth APIs to import the shared helper functions instead of redefining them

## Testing
- `npm test -- --watch=false` *(fails: existing supervisord route stream tests expect mocked stream routes and timers)*

------
https://chatgpt.com/codex/tasks/task_e_68d61ac9b568832e9dea6c58a3b8ca72