### PR TITLE
Remove unused admin session helpers

### DIFF
--- a/server/session.js
+++ b/server/session.js
@@ -27,16 +27,6 @@ export function isSessionAuthenticated(session) {
 }
 
 /**
- * Determines whether the session user has the Administrator role.
- *
- * @param {RequestSession | undefined | null} session
- * @returns {boolean}
- */
-export function isSessionAdmin(session) {
-  return sessionHasRole(session, [ROLE_ADMIN]);
-}
-
-/**
  * Determines whether the session user has one of the specified roles.
  *
  * @param {RequestSession | undefined | null} session
@@ -96,19 +86,6 @@ export function ensureRoleRequest(req, res, roles, redirectTo = '/request-access
   }
 
   return true;
-}
-
-/**
- * Ensures the current request belongs to an authenticated administrator. The
- * return value mirrors {@link ensureAuthenticatedRequest}.
- *
- * @param {Request & { session?: RequestSession }} req
- * @param {Response} res
- * @param {string} [redirectTo='/dashboard']
- * @returns {boolean}
- */
-export function ensureAdminRequest(req, res, redirectTo = '/request-access') {
-  return ensureRoleRequest(req, res, [ROLE_ADMIN], redirectTo);
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove the unused admin-focused helpers from `server/session.js`
- confirm there are no remaining references to the deleted helpers

## Testing
- npm test *(fails: existing stream route handler and timer spying expectations in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d61ba14b9c832e8bce5e2b1fa0a448