### PR TITLE
Remove safeUrlProtocols export

### DIFF
--- a/shared/url.js
+++ b/shared/url.js
@@ -55,4 +55,3 @@ export function assertSafeUrl(value, message = 'URL must be a valid http(s) URL.
   return normalized;
 }
 
-export const safeUrlProtocols = SAFE_URL_PROTOCOLS;


### PR DESCRIPTION
## Summary
- remove the unused `safeUrlProtocols` export from the shared URL utilities

## Testing
- npm run lint *(fails: Parsing error: Unexpected token assert in server/context.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d61ba84f1c832eb65ad1af9e2b75d9