### PR TITLE
Ensure idle timeout clears scoped session cookies

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -68,12 +68,28 @@ export function createApp(context) {
     const now = Date.now();
     const lastActivity = req.session.lastActivityAt;
     if (typeof lastActivity === 'number' && now - lastActivity > idleTimeout) {
+      const cookieConfig = config.session.cookie ?? {};
+      const cookieOptions = { path: cookieConfig.path ?? '/' };
+
+      if (cookieConfig.domain !== undefined) {
+        cookieOptions.domain = cookieConfig.domain;
+      }
+      if (cookieConfig.sameSite !== undefined) {
+        cookieOptions.sameSite = cookieConfig.sameSite;
+      }
+      if (cookieConfig.secure !== undefined) {
+        cookieOptions.secure = cookieConfig.secure;
+      }
+      if (cookieConfig.httpOnly !== undefined) {
+        cookieOptions.httpOnly = cookieConfig.httpOnly;
+      }
+
       req.session.destroy((err) => {
         if (err) {
           next(err);
           return;
         }
-        res.clearCookie(config.session.name);
+        res.clearCookie(config.session.name, cookieOptions);
         next();
       });
       return;


### PR DESCRIPTION
## Summary
- align the idle-timeout middleware with the auth routes so it clears cookies using the configured path/domain/samesite/httpOnly options
- extend the application tests to cover idle timeout behaviour and verify scoped session cookies are removed when the session expires

## Testing
- npm test -- app.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d6186e0a74832eab863388bff3ed7c