### PR TITLE
Ensure session refresh handles missing backend session

### DIFF
--- a/__tests__/client/sessionRefresh.test.js
+++ b/__tests__/client/sessionRefresh.test.js
@@ -1,0 +1,27 @@
+import { jest } from '@jest/globals';
+
+import { refreshSessionState } from '../../client/src/sessionContext.jsx';
+import { resolveRequireAuth } from '../../client/src/routeGuards.jsx';
+
+describe('session refresh behaviour', () => {
+  it('marks the session unauthenticated when the backend returns no user', async () => {
+    const authClient = { getSession: jest.fn().mockResolvedValue({ allowSelfRegistration: false, user: null }) };
+    const setAllowSelfRegistration = jest.fn();
+    const setUser = jest.fn();
+    const setStatus = jest.fn();
+
+    await refreshSessionState({ authClient, setAllowSelfRegistration, setUser, setStatus });
+
+    expect(authClient.getSession).toHaveBeenCalledTimes(1);
+    expect(setAllowSelfRegistration).toHaveBeenCalledWith(false);
+    expect(setUser).toHaveBeenCalledWith(null);
+    expect(setStatus).toHaveBeenLastCalledWith('unauthenticated');
+  });
+});
+
+describe('route guard behaviour', () => {
+  it('redirects unauthenticated users to the login page', () => {
+    const decision = resolveRequireAuth({ status: 'unauthenticated', user: null, pathname: '/request-access' });
+    expect(decision).toEqual({ type: 'redirect', to: '/auth/login' });
+  });
+});

--- a/client/src/__mocks__/apiClient.cjs
+++ b/client/src/__mocks__/apiClient.cjs
@@ -1,0 +1,3 @@
+const createAuthClient = jest.fn();
+
+module.exports = { createAuthClient };

--- a/client/src/pages/LoginPage.jsx
+++ b/client/src/pages/LoginPage.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 
-import { useSession } from '../App.jsx';
+import { useSession } from '../sessionContext.jsx';
 import AuthPageLayout from './AuthPageLayout.jsx';
 import ui from '../styles/ui.module.css';
 

--- a/client/src/pages/RegisterPage.jsx
+++ b/client/src/pages/RegisterPage.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 
-import { useSession } from '../App.jsx';
+import { useSession } from '../sessionContext.jsx';
 import AuthPageLayout from './AuthPageLayout.jsx';
 import ui from '../styles/ui.module.css';
 import { checkPasswordAgainstPolicy, PASSWORD_POLICY_SUMMARY } from '../../shared/passwordPolicy.js';

--- a/client/src/pages/RequestAccessPage.jsx
+++ b/client/src/pages/RequestAccessPage.jsx
@@ -1,4 +1,4 @@
-import { useSession } from '../App.jsx';
+import { useSession } from '../sessionContext.jsx';
 import ui from '../styles/ui.module.css';
 
 export default function RequestAccessPage() {

--- a/client/src/routeGuards.jsx
+++ b/client/src/routeGuards.jsx
@@ -1,0 +1,85 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+
+import { useSession } from './sessionContext.jsx';
+import ui from './styles/ui.module.css';
+import {
+  ROLE_ADMIN,
+  ROLE_MANAGER,
+  ROLE_NONE,
+  ROLE_VIEWER,
+  resolveUserRole,
+  userHasRole
+} from '../../shared/roles.js';
+
+function LoadingView({ message = 'Loading…' }) {
+  return (
+    <div className={ui.loadingContainer}>
+      <div className={ui.loadingContent}>
+        <div className={`${ui.spinner} ${ui.textCenter}`} role="status" aria-hidden="true"></div>
+        <p className={ui.textMuted}>{message}</p>
+      </div>
+    </div>
+  );
+}
+
+export function resolveRequireAuth({ status, user, pathname }) {
+  if (status === 'loading') {
+    return { type: 'loading' };
+  }
+
+  if (status !== 'authenticated') {
+    return { type: 'redirect', to: '/auth/login' };
+  }
+
+  const role = resolveUserRole(user);
+  if (role === ROLE_NONE && !pathname.startsWith('/request-access') && !pathname.startsWith('/auth')) {
+    return { type: 'redirect', to: '/request-access' };
+  }
+
+  return { type: 'allow' };
+}
+
+function RequireAuth() {
+  const location = useLocation();
+  const { status, user } = useSession();
+  const decision = resolveRequireAuth({ status, user, pathname: location.pathname });
+
+  if (decision.type === 'loading') {
+    return <LoadingView message="Checking session…" />;
+  }
+
+  if (decision.type === 'redirect') {
+    return <Navigate to={decision.to} state={{ from: location }} replace />;
+  }
+
+  return <Outlet />;
+}
+
+function RequireRole({ allowedRoles, children }) {
+  const { user } = useSession();
+  const location = useLocation();
+  const role = resolveUserRole(user);
+
+  if (!userHasRole(user, allowedRoles)) {
+    const redirectTo = role === ROLE_NONE ? '/request-access' : '/dashboard';
+    return <Navigate to={redirectTo} state={{ from: location }} replace />;
+  }
+
+  return children;
+}
+
+function RequireGuest({ children }) {
+  const { status } = useSession();
+
+  if (status === 'loading') {
+    return <LoadingView message="Checking session…" />;
+  }
+
+  if (status === 'authenticated') {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return children;
+}
+
+export { LoadingView, RequireAuth, RequireGuest, RequireRole };

--- a/client/src/sessionContext.jsx
+++ b/client/src/sessionContext.jsx
@@ -1,0 +1,155 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+
+import { createAuthClient } from './apiClient.js';
+
+export async function refreshSessionState({
+  authClient,
+  setAllowSelfRegistration,
+  setUser,
+  setStatus
+}) {
+  const data = await authClient.getSession();
+  if (data && Object.prototype.hasOwnProperty.call(data, 'allowSelfRegistration')) {
+    setAllowSelfRegistration(Boolean(data.allowSelfRegistration));
+  }
+  const sessionUser = data?.user ?? null;
+  setUser(sessionUser);
+  setStatus(sessionUser ? 'authenticated' : 'unauthenticated');
+  return sessionUser;
+}
+
+export const SessionContext = createContext({
+  user: null,
+  status: 'loading',
+  allowSelfRegistration: false,
+  login: async () => {},
+  logout: async () => {},
+  register: async () => {},
+  refreshSession: async () => {}
+});
+
+export function useSession() {
+  return useContext(SessionContext);
+}
+
+export function SessionProvider({ initialState, children, authClientFactory = createAuthClient }) {
+  const authClient = useMemo(
+    () => authClientFactory(initialState?.auth),
+    [authClientFactory, initialState]
+  );
+  const [user, setUser] = useState(initialState?.user ?? null);
+  const [status, setStatus] = useState(initialState?.user ? 'authenticated' : 'loading');
+  const [allowSelfRegistration, setAllowSelfRegistration] = useState(
+    initialState?.auth?.allowSelfRegistration ?? false
+  );
+  const initialUserPresentRef = useRef(Boolean(initialState?.user));
+  const initialFetchCompleted = useRef(false);
+
+  const refreshSession = useCallback(
+    async ({ background = false } = {}) => {
+      if (!background) {
+        setStatus('loading');
+      }
+      try {
+        return await refreshSessionState({
+          authClient,
+          setAllowSelfRegistration,
+          setUser,
+          setStatus
+        });
+      } catch (err) {
+        setUser(null);
+        setStatus('unauthenticated');
+        throw err;
+      }
+    },
+    [authClient]
+  );
+
+  useEffect(() => {
+    if (initialFetchCompleted.current) {
+      return;
+    }
+    initialFetchCompleted.current = true;
+    refreshSession({ background: initialUserPresentRef.current }).catch(() => {
+      /* handled by refreshSession */
+    });
+  }, [refreshSession]);
+
+  const login = useCallback(
+    async ({ email, password }) => {
+      setStatus('loading');
+      try {
+        const result = await authClient.login({ email, password });
+        const sessionUser = result?.user ?? null;
+        setUser(sessionUser);
+        setStatus(sessionUser ? 'authenticated' : 'unauthenticated');
+        return sessionUser;
+      } catch (err) {
+        setUser(null);
+        setStatus('unauthenticated');
+        throw err;
+      }
+    },
+    [authClient]
+  );
+
+  const register = useCallback(
+    async ({ name, email, password }) => {
+      if (!allowSelfRegistration) {
+        throw new Error('Self-registration is disabled.');
+      }
+      setStatus('loading');
+      try {
+        const result = await authClient.register({ name, email, password });
+        const sessionUser = result?.user ?? null;
+        setUser(sessionUser);
+        setStatus(sessionUser ? 'authenticated' : 'unauthenticated');
+        return sessionUser;
+      } catch (err) {
+        setUser(null);
+        setStatus('unauthenticated');
+        throw err;
+      }
+    },
+    [authClient, allowSelfRegistration]
+  );
+
+  const logout = useCallback(
+    async () => {
+      setStatus('loading');
+      try {
+        await authClient.logout();
+        setUser(null);
+        setStatus('unauthenticated');
+      } catch (err) {
+        setStatus(user ? 'authenticated' : 'unauthenticated');
+        throw err;
+      }
+    },
+    [authClient, user]
+  );
+
+  const value = useMemo(
+    () => ({
+      user,
+      status,
+      allowSelfRegistration,
+      login,
+      logout,
+      register,
+      refreshSession
+    }),
+    [user, status, allowSelfRegistration, login, logout, register, refreshSession]
+  );
+
+  return <SessionContext.Provider value={value}>{children}</SessionContext.Provider>;
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,9 @@ export default {
     '^.+\\.[jt]sx?$': ['babel-jest', { configFile: './babel.config.cjs' }]
   },
   moduleNameMapper: {
-    '\\.(css|less|sass|scss)$': 'identity-obj-proxy'
+    '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
+    'apiClient\\.js$': '<rootDir>/client/src/__mocks__/apiClient.cjs',
+    'shared/roles\\.js$': '<rootDir>/shared/__mocks__/roles.cjs'
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js']
 };

--- a/shared/__mocks__/roles.cjs
+++ b/shared/__mocks__/roles.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  ROLE_ADMIN: 'admin',
+  ROLE_MANAGER: 'manager',
+  ROLE_NONE: 'none',
+  ROLE_VIEWER: 'viewer',
+  resolveUserRole: (user) => (user && user.role) || 'none',
+  userHasRole: (user, allowed) => allowed.includes((user && user.role) || 'none')
+};


### PR DESCRIPTION
## Summary
- move the session provider into a dedicated module that supports injectable auth clients and expose a reusable `refreshSessionState` helper
- refactor the route guards into their own module with a testable `resolveRequireAuth` helper and update the app/pages to consume the new exports
- add focused unit tests and jest mappings to cover the unauthenticated refresh case and guard redirect logic

## Testing
- npm test -- sessionRefresh

------
https://chatgpt.com/codex/tasks/task_e_68d6188236a8832eb896b06991000bd0