### PR TITLE
Add max length validation to auth and user schemas

### DIFF
--- a/routes/api/auth.js
+++ b/routes/api/auth.js
@@ -218,7 +218,7 @@ const loginRequestSchema = z.object({
 });
 
 const registrationSchema = z.object({
-  name: requiredTrimmedString('Name'),
+  name: requiredTrimmedString('Name', { max: 32 }),
   email: emailSchema.transform((value) => value.toLowerCase()),
   password: passwordSchema
 });

--- a/routes/api/schemaHelpers.js
+++ b/routes/api/schemaHelpers.js
@@ -1,13 +1,22 @@
 import { z } from 'zod';
 
-export function requiredTrimmedString(field) {
-  return z.preprocess(
-    (value) => (value === undefined ? value : String(value)),
-    z
-      .string({ required_error: `${field} is required.` })
-      .trim()
-      .min(1, `${field} is required.`)
-  );
+/**
+ * @param {string} field
+ * @param {{ max?: number }} [options]
+ */
+export function requiredTrimmedString(field, options) {
+  const { max } = options ?? {};
+
+  let schema = z
+    .string({ required_error: `${field} is required.` })
+    .trim()
+    .min(1, `${field} is required.`);
+
+  if (typeof max === 'number') {
+    schema = schema.max(max, `${field} must be at most ${max} characters.`);
+  }
+
+  return z.preprocess((value) => (value === undefined ? value : String(value)), schema);
 }
 
 export function normalizedEmailSchema(field) {
@@ -17,6 +26,7 @@ export function normalizedEmailSchema(field) {
       .string({ required_error: `${field} is required.` })
       .trim()
       .min(1, `${field} is required.`)
+      .max(128, `${field} must be at most 128 characters.`)
       .email('Invalid email address.')
   );
 }

--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -134,7 +134,7 @@ export function createUsersApi(context) {
   return router;
 }
 
-const roleSchema = requiredTrimmedString('Role').refine((value) => ALL_ROLES.includes(value), 'Invalid role.');
+const roleSchema = requiredTrimmedString('Role', { max: 32 }).refine((value) => ALL_ROLES.includes(value), 'Invalid role.');
 
 const emailSchema = normalizedEmailSchema('Email');
 
@@ -151,14 +151,14 @@ const passwordSchema = z
   });
 
 const userCreateSchema = z.object({
-  name: requiredTrimmedString('Name'),
+  name: requiredTrimmedString('Name', { max: 32 }),
   email: emailSchema.transform((value) => value.toLowerCase()),
   role: roleSchema,
   password: passwordSchema
 });
 
 const userUpdateSchema = z.object({
-  name: requiredTrimmedString('Name'),
+  name: requiredTrimmedString('Name', { max: 32 }),
   email: emailSchema.transform((value) => value.toLowerCase()),
   role: roleSchema,
   password: passwordSchema.optional()


### PR DESCRIPTION
## Summary
- add optional max length support to requiredTrimmedString helper and enforce email length limit
- enforce name and role length limits in auth and users API validation schemas

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d61e1dd764832e8635a63b6d7c5b14