### PR TITLE
Preserve session on background refresh failures

### DIFF
--- a/__tests__/client/sessionRefresh.test.js
+++ b/__tests__/client/sessionRefresh.test.js
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals';
 
-import { refreshSessionState } from '../../client/src/sessionContext.jsx';
+import { refreshSessionState, createRefreshSessionHandler } from '../../client/src/sessionContext.jsx';
 import { resolveRequireAuth } from '../../client/src/routeGuards.jsx';
 
 describe('session refresh behaviour', () => {
@@ -16,6 +16,40 @@ describe('session refresh behaviour', () => {
     expect(setAllowSelfRegistration).toHaveBeenCalledWith(false);
     expect(setUser).toHaveBeenCalledWith(null);
     expect(setStatus).toHaveBeenLastCalledWith('unauthenticated');
+  });
+});
+
+describe('SessionProvider refreshSession behaviour', () => {
+  it('keeps the session authenticated when a background refresh encounters a non-auth error', async () => {
+    const existingUser = { id: 'user-1', name: 'Existing User' };
+    let currentUser = existingUser;
+    let currentStatus = 'authenticated';
+    const setAllowSelfRegistration = jest.fn();
+    const setUser = jest.fn((value) => {
+      currentUser = value;
+    });
+    const setStatus = jest.fn((value) => {
+      currentStatus = value;
+    });
+    const getSession = jest
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('network failure'), { status: 500 }));
+
+    const refreshSession = createRefreshSessionHandler({
+      authClient: { getSession },
+      setAllowSelfRegistration,
+      setUser,
+      setStatus
+    });
+
+    await expect(refreshSession({ background: true })).rejects.toThrow('network failure');
+
+    expect(getSession).toHaveBeenCalledTimes(1);
+    expect(setAllowSelfRegistration).not.toHaveBeenCalled();
+    expect(setUser).not.toHaveBeenCalled();
+    expect(setStatus).not.toHaveBeenCalled();
+    expect(currentUser).toEqual(existingUser);
+    expect(currentStatus).toBe('authenticated');
   });
 });
 


### PR DESCRIPTION
## Summary
- extract the session refresh logic into a reusable helper that preserves authentication state during background errors
- keep the refresh callback clearing auth data only for foreground refreshes or explicit 401/403 responses
- add a regression test covering background refresh failures to ensure the session remains authenticated

## Testing
- npm test -- sessionRefresh

------
https://chatgpt.com/codex/tasks/task_e_68d620effc3c832eb29931e6238b2467