### PR TITLE
Normalize database client identifiers

### DIFF
--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -29,3 +29,27 @@ describe('config trust proxy parsing', () => {
     expect(config.trustProxy).toBe(true);
   });
 });
+
+describe('config database client normalization', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.DB_CLIENT;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it.each([
+    ['MYSQL2', 'mysql2'],
+    ['PostgresQL', 'pg'],
+    ['SQLite3', 'sqlite3']
+  ])('normalizes %s to %s', async (input, expected) => {
+    process.env.DB_CLIENT = input;
+
+    const { default: config } = await import('../config.js');
+
+    expect(config.db.client).toBe(expected);
+  });
+});

--- a/__tests__/knexfile.test.js
+++ b/__tests__/knexfile.test.js
@@ -1,0 +1,27 @@
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe('knexfile client normalization', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.DB_CLIENT;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it.each([
+    ['MYSQL2', 'mysql2'],
+    ['PostgresQL', 'pg'],
+    ['SQLite3', 'sqlite3']
+  ])('normalizes %s to %s', async (input, expected) => {
+    process.env.DB_CLIENT = input;
+
+    const knexConfig = (await import('../knexfile.cjs')).default;
+
+    expect(knexConfig.production.client).toBe(expected);
+  });
+});

--- a/config.js
+++ b/config.js
@@ -467,7 +467,7 @@ function normalizeClientName(client) {
     return 'pg';
   }
 
-  return client;
+  return normalized;
 }
 
 function createDashboardConfig({ publicDir, publicPath, entry, manifestList }) {

--- a/knexfile.cjs
+++ b/knexfile.cjs
@@ -115,7 +115,7 @@ function normalizeClientName(client) {
     return 'pg';
   }
 
-  return client;
+  return normalized;
 }
 
 function loadEnvironmentFiles(rootDir) {


### PR DESCRIPTION
## Summary
- ensure config and knexfile always return lower-cased database client identifiers after applying aliases
- add tests covering MySQL, Postgres, and SQLite client name normalization

## Testing
- npm test -- __tests__/config.test.js __tests__/knexfile.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d620e8ac48832ebc182b1bfe2fbbdb