### PR TITLE
Fix server context JSON import for Node compatibility

### DIFF
--- a/server/context.js
+++ b/server/context.js
@@ -1,7 +1,10 @@
+import { createRequire } from 'module';
 import { createGroupsRepository } from '../data/groups.js';
 import { createHostsRepository } from '../data/hosts.js';
 import { createUsersRepository } from '../data/users.js';
-import packageJson from '../package.json' assert { type: 'json' };
+
+const require = createRequire(import.meta.url);
+const packageJson = require('../package.json');
 
 /** @typedef {import('./types.js').ServerContext} ServerContext */
 /** @typedef {import('./types.js').ServerConfig} ServerConfig */


### PR DESCRIPTION
## Summary
- load package metadata in the server context using createRequire instead of JSON import assertions
- ensure the server context still exposes the package version without requiring Node import-assertion support

## Testing
- npm run start *(fails: SQLITE_ERROR: no such table: hosts)*

------
https://chatgpt.com/codex/tasks/task_e_68d69c58611c832e9ce6c94ff6c10c78