### PR TITLE
Restore service dashboard and add overview page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import {
 import { useState } from 'react';
 
 import Dashboard from './Dashboard.jsx';
+import OverviewPage from './pages/OverviewPage.jsx';
 import HostsListPage from './pages/HostsListPage.jsx';
 import HostFormPage from './pages/HostFormPage.jsx';
 import GroupsListPage from './pages/GroupsListPage.jsx';
@@ -64,11 +65,18 @@ function Layout() {
           <nav aria-label="Primary navigation">
             <ul className={layoutStyles.navList}>
               {canViewDashboard && (
-                <li>
-                  <Link to="/dashboard" className={layoutStyles.navLink}>
-                    Dashboard
-                  </Link>
-                </li>
+                <>
+                  <li>
+                    <Link to="/dashboard" className={layoutStyles.navLink}>
+                      Dashboard
+                    </Link>
+                  </li>
+                  <li>
+                    <Link to="/overview" className={layoutStyles.navLink}>
+                      Overview
+                    </Link>
+                  </li>
+                </>
               )}
               {canManageInfrastructure && (
                 <>
@@ -132,6 +140,14 @@ function AppRoutes() {
             element={
               <RequireRole allowedRoles={[ROLE_ADMIN, ROLE_MANAGER, ROLE_VIEWER]}>
                 <Dashboard />
+              </RequireRole>
+            }
+          />
+          <Route
+            path="overview"
+            element={
+              <RequireRole allowedRoles={[ROLE_ADMIN, ROLE_MANAGER, ROLE_VIEWER]}>
+                <OverviewPage />
               </RequireRole>
             }
           />

--- a/client/src/Dashboard.jsx
+++ b/client/src/Dashboard.jsx
@@ -1,18 +1,18 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
+import { requestJson } from './apiClient.js';
+import {
+  STATUS_META,
+  StatusIcon,
+  formatDuration,
+  formatProcessIdentifier,
+  formatTimestamp,
+  summarizeProcesses,
+  useSupervisorData
+} from './supervisorData.jsx';
 import dashboardStyles from './Dashboard.module.css';
 import ui from './styles/ui.module.css';
-
-const STATUS_ORDER = ['CONERR', 'FATAL', 'EXITED', 'STARTING', 'RUNNING', 'STOPPED', 'BACKOFF'];
-const STATUS_META = {
-  CONERR: { tone: 'danger', icon: 'bolt' },
-  FATAL: { tone: 'danger', icon: 'alert' },
-  EXITED: { tone: 'danger', icon: 'alert' },
-  STARTING: { tone: 'warning', icon: 'refresh' },
-  RUNNING: { tone: 'success', icon: 'check' },
-  STOPPED: { tone: 'info', icon: 'pause' },
-  BACKOFF: { tone: 'info', icon: 'pause' }
-};
+import { isSafeUrl } from '../../shared/url.js';
 
 const STATUS_TONE_CLASS = {
   danger: dashboardStyles.statusToneDanger,
@@ -25,358 +25,550 @@ function classNames(...values) {
   return values.filter(Boolean).join(' ');
 }
 
-function StatusIcon({ name, className }) {
-  switch (name) {
-    case 'bolt':
-      return (
-        <svg className={className} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path
-            fill="currentColor"
-            d="M11.25 2.25a.75.75 0 01.654.37l4.5 7.5a.75.75 0 01-.654 1.13H12v8.5a.75.75 0 01-1.404.36l-4.5-7.5A.75.75 0 016.75 11H10V2.75a.75.75 0 01.75-.75z"
-          />
-        </svg>
-      );
-    case 'alert':
-      return (
-        <svg className={className} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path
-            fill="currentColor"
-            d="M12 2a10 10 0 1010 10A10 10 0 0012 2zm0 5a1 1 0 01.993.883L13 8v5a1 1 0 01-1.993.117L11 13V8a1 1 0 011-1zm0 9.25a1.25 1.25 0 11-1.25 1.25A1.25 1.25 0 0112 16.25z"
-          />
-        </svg>
-      );
-    case 'refresh':
-      return (
-        <svg className={className} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path
-            fill="currentColor"
-            d="M3.978 8.223a9 9 0 0114.962-3.74V3.75a.75.75 0 011.5 0v4.5a.75.75 0 01-.75.75h-4.5a.75.75 0 010-1.5h2.385a7.5 7.5 0 10.748 7.105.75.75 0 111.318.75A9 9 0 113.978 8.223z"
-          />
-        </svg>
-      );
-    case 'check':
-      return (
-        <svg className={className} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path
-            fill="currentColor"
-            d="M12 2a10 10 0 1010 10A10 10 0 0012 2zm4.28 7.22l-5 5a.75.75 0 01-1.06 0l-2-2a.75.75 0 111.06-1.06L11 12.94l4.22-4.22a.75.75 0 111.06 1.06z"
-          />
-        </svg>
-      );
-    case 'pause':
+function formatStatusLabel(status) {
+  if (!status) {
+    return 'Unknown';
+  }
+
+  const normalized = status.toUpperCase();
+  switch (normalized) {
+    case 'CONERR':
+      return 'Connection error';
+    case 'FATAL':
+      return 'Fatal';
+    case 'EXITED':
+      return 'Exited';
+    case 'STARTING':
+      return 'Starting';
+    case 'RUNNING':
+      return 'Running';
+    case 'STOPPED':
+      return 'Stopped';
+    case 'BACKOFF':
+      return 'Backoff';
     default:
-      return (
-        <svg className={className} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-          <path
-            fill="currentColor"
-            d="M12 2a10 10 0 1010 10A10 10 0 0012 2zm-2.25 5.75a.75.75 0 00-.75.75v7a.75.75 0 001.5 0v-7a.75.75 0 00-.75-.75zm4.5 0a.75.75 0 00-.75.75v7a.75.75 0 001.5 0v-7a.75.75 0 00-.75-.75z"
-          />
-        </svg>
-      );
+      return normalized.charAt(0) + normalized.slice(1).toLowerCase();
   }
 }
 
-function transformHosts(rawHosts) {
-  const entries = Object.entries(rawHosts ?? {}).sort(([a], [b]) => a.localeCompare(b));
-  const grouped = new Map();
+function StatusBadge({ status, children }) {
+  const normalized = typeof status === 'string' ? status.toUpperCase() : 'CONERR';
+  const meta = STATUS_META[normalized] ?? STATUS_META.CONERR;
+  const toneClass = STATUS_TONE_CLASS[meta.tone] ?? STATUS_TONE_CLASS.info;
+  const label = children ?? formatStatusLabel(normalized);
 
-  for (const [, value] of entries) {
-    if (!value || !value.host) {
-      continue;
-    }
-
-    const { host, data = [] } = value;
-    const groupName = host.GroupName;
-
-    if (groupName) {
-      const existing = grouped.get(groupName);
-      if (existing) {
-        existing.data = existing.data.concat(Array.isArray(data) ? data : []);
-      } else {
-        grouped.set(groupName, {
-          host: { Name: groupName },
-          data: Array.isArray(data) ? [...data] : []
-        });
-      }
-    } else {
-      const key = host.Name ?? '';
-      if (!grouped.has(key)) {
-        grouped.set(key, {
-          host,
-          data: Array.isArray(data) ? data : data && data.errno ? [data] : []
-        });
-      } else {
-        const existing = grouped.get(key);
-        existing.data = existing.data.concat(Array.isArray(data) ? data : []);
-      }
-    }
-  }
-
-  return Array.from(grouped.values());
+  return (
+    <span className={classNames(dashboardStyles.statusBadge, toneClass)}>
+      <StatusIcon name={meta.icon} className={dashboardStyles.statusIcon} />
+      <span>{label}</span>
+    </span>
+  );
 }
 
-function summarizeProcesses(processes) {
-  if (!Array.isArray(processes) || processes.some((proc) => proc && proc.errno)) {
-    return { status: 'CONERR', count: 'NA' };
-  }
-
-  const counts = new Map();
-  for (const proc of processes) {
-    const status = proc?.statename;
-    if (!status) {
-      continue;
-    }
-    counts.set(status, (counts.get(status) ?? 0) + 1);
-  }
-
-  if (counts.size === 0) {
-    return { status: 'CONERR', count: 'NA' };
-  }
-
-  const [status, count] = [...counts.entries()].sort(
-    ([statusA], [statusB]) => STATUS_ORDER.indexOf(statusA) - STATUS_ORDER.indexOf(statusB)
-  )[0];
-
-  return { status, count };
+function createLogState() {
+  return {
+    out: { content: '', offset: 0, overflow: false, loading: false, error: null },
+    err: { content: '', offset: 0, overflow: false, loading: false, error: null }
+  };
 }
 
-function useDashboardData(pollInterval) {
-  const [hosts, setHosts] = useState([]);
-  const [error, setError] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const initialLoad = useRef(true);
-  const hostState = useRef(new Map());
-  const controllerRef = useRef(null);
-  const fallbackTimerRef = useRef(null);
-  const eventSourceRef = useRef(null);
-  const reconnectTimerRef = useRef(null);
+function ProcessLogDialog({ open, hostId, hostName, processName, displayName, onClose }) {
+  const [activeTab, setActiveTab] = useState('out');
+  const [logState, setLogState] = useState(() => createLogState());
+  const [reloadToken, setReloadToken] = useState(0);
+  const [clearing, setClearing] = useState(false);
 
   useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setActiveTab('out');
+    setLogState(createLogState());
+    setReloadToken((token) => token + 1);
+  }, [open, hostId, processName]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
     let cancelled = false;
-    const fallbackInterval = Math.max(Number(pollInterval) || 0, 60000);
 
-    const applyRawHosts = (rawHosts) => {
-      const normalized = rawHosts && typeof rawHosts === 'object' ? rawHosts : {};
-      hostState.current = new Map(Object.entries(normalized));
-      setHosts(transformHosts(normalized));
-      if (initialLoad.current) {
-        setLoading(false);
-        initialLoad.current = false;
-      }
-    };
+    setLogState((prev) => ({
+      ...prev,
+      [activeTab]: { ...prev[activeTab], loading: true, error: null }
+    }));
 
-    const applyUpdatePayload = (payload) => {
-      const current = new Map(hostState.current);
-      if (payload?.updates && typeof payload.updates === 'object') {
-        for (const [hostId, entry] of Object.entries(payload.updates)) {
-          current.set(hostId, entry);
-        }
-      }
-      if (Array.isArray(payload?.removed)) {
-        for (const hostId of payload.removed) {
-          current.delete(hostId);
-        }
-      }
-
-      hostState.current = current;
-      setHosts(transformHosts(Object.fromEntries(current)));
-      if (initialLoad.current) {
-        setLoading(false);
-        initialLoad.current = false;
-      }
-    };
-
-    const clearFallbackTimer = () => {
-      if (fallbackTimerRef.current) {
-        clearTimeout(fallbackTimerRef.current);
-        fallbackTimerRef.current = null;
-      }
-    };
-
-    const scheduleFallbackFetch = () => {
-      clearFallbackTimer();
-      fallbackTimerRef.current = setTimeout(() => {
-        performFetch({ showLoading: false, scheduleNext: true });
-      }, fallbackInterval);
-      if (typeof fallbackTimerRef.current?.unref === 'function') {
-        fallbackTimerRef.current.unref();
-      }
-    };
-
-    const performFetch = async ({ showLoading, scheduleNext } = {}) => {
-      if (cancelled) {
-        return;
-      }
-
-      if (showLoading && initialLoad.current) {
-        setLoading(true);
-      }
-
-      if (controllerRef.current) {
-        controllerRef.current.abort();
-      }
-
-      const controller = new AbortController();
-      controllerRef.current = controller;
-
+    async function loadLogs() {
       try {
-        const response = await fetch('/api/v1/supervisors', {
-          headers: { Accept: 'application/json' },
-          signal: controller.signal,
-          credentials: 'same-origin'
+        const query = new URLSearchParams({
+          host: hostId,
+          process: processName,
+          type: activeTab
         });
-
-        if (!response.ok) {
-          throw new Error(`Request failed with status ${response.status}`);
-        }
-
-        const payload = await response.json();
+        const data = await requestJson(`/api/v1/supervisors/logs?${query.toString()}`);
         if (cancelled) {
           return;
         }
 
-        applyRawHosts(payload?.data);
-        setError(null);
+        const [content, offset, overflow] = Array.isArray(data) ? data : ['', 0, false];
+        setLogState((prev) => ({
+          ...prev,
+          [activeTab]: {
+            ...prev[activeTab],
+            loading: false,
+            content: typeof content === 'string' ? content : '',
+            offset: Number.isFinite(Number(offset)) ? Number(offset) : 0,
+            overflow: Boolean(overflow),
+            error: null
+          }
+        }));
       } catch (err) {
-        if (cancelled || err.name === 'AbortError') {
-          return;
-        }
-        setError(err.message ?? 'Failed to load dashboard data.');
-      } finally {
-        if (scheduleNext && !cancelled) {
-          scheduleFallbackFetch();
-        }
-      }
-    };
-
-    const clearReconnectTimer = () => {
-      if (reconnectTimerRef.current) {
-        clearTimeout(reconnectTimerRef.current);
-        reconnectTimerRef.current = null;
-      }
-    };
-
-    const startStream = () => {
-      if (cancelled) {
-        return;
-      }
-
-      if (eventSourceRef.current) {
-        eventSourceRef.current.close();
-        eventSourceRef.current = null;
-      }
-
-      const source = new EventSource('/api/v1/supervisors/stream');
-      eventSourceRef.current = source;
-
-      source.onopen = () => {
-        setError(null);
-      };
-
-      source.addEventListener('snapshot', (event) => {
-        try {
-          const payload = JSON.parse(event.data);
-          applyRawHosts(payload);
-          setError(null);
-        } catch (_err) {
-          setError('Received malformed supervisor snapshot.');
-        }
-      });
-
-      source.addEventListener('update', (event) => {
-        try {
-          const payload = JSON.parse(event.data);
-          applyUpdatePayload(payload);
-          setError(null);
-        } catch (_err) {
-          setError('Received malformed supervisor update.');
-        }
-      });
-
-      source.onerror = () => {
         if (cancelled) {
           return;
         }
+        setLogState((prev) => ({
+          ...prev,
+          [activeTab]: {
+            ...prev[activeTab],
+            loading: false,
+            error: err.message ?? 'Failed to load logs.'
+          }
+        }));
+      }
+    }
 
-        setError((current) => current ?? 'Reconnecting to supervisor stream…');
-
-        if (source.readyState === EventSource.CLOSED && !reconnectTimerRef.current) {
-          reconnectTimerRef.current = setTimeout(() => {
-            reconnectTimerRef.current = null;
-            startStream();
-          }, 3000);
-        }
-      };
-    };
-
-    performFetch({ showLoading: true, scheduleNext: true });
-    startStream();
+    loadLogs();
 
     return () => {
       cancelled = true;
-      if (controllerRef.current) {
-        controllerRef.current.abort();
-        controllerRef.current = null;
-      }
-      clearFallbackTimer();
-      clearReconnectTimer();
-      if (eventSourceRef.current) {
-        eventSourceRef.current.close();
-        eventSourceRef.current = null;
+    };
+  }, [open, activeTab, hostId, processName, reloadToken]);
+
+  useEffect(() => {
+    if (!open || typeof document === 'undefined') {
+      return undefined;
+    }
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        onClose();
       }
     };
-  }, [pollInterval]);
 
-  return { hosts, error, loading };
-}
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, onClose]);
 
-function HostCard({ host, processes }) {
-  const summary = useMemo(() => summarizeProcesses(processes), [processes]);
-  const meta = STATUS_META[summary.status] ?? STATUS_META.CONERR;
-  const label = summary.count;
-  const toneClass = STATUS_TONE_CLASS[meta.tone] ?? dashboardStyles.statusToneInfo;
+  if (!open) {
+    return null;
+  }
+
+  const tabState = logState[activeTab] ?? logState.out;
+  const tabs = [
+    { key: 'out', label: 'Stdout' },
+    { key: 'err', label: 'Stderr' }
+  ];
+
+  const handleRefresh = () => {
+    setReloadToken((token) => token + 1);
+  };
+
+  const handleClear = async () => {
+    setClearing(true);
+    try {
+      await requestJson('/api/v1/supervisors/logs/clear', {
+        method: 'POST',
+        body: JSON.stringify({ host: hostId, process: processName })
+      });
+      setReloadToken((token) => token + 1);
+    } catch (err) {
+      setLogState((prev) => ({
+        ...prev,
+        [activeTab]: {
+          ...prev[activeTab],
+          error: err.message ?? 'Failed to clear logs.'
+        }
+      }));
+    } finally {
+      setClearing(false);
+    }
+  };
+
+  const logLabel = activeTab === 'out' ? 'stdout' : 'stderr';
 
   return (
-    <div className={dashboardStyles.card}>
-      <div className={dashboardStyles.cardBody}>
-        <h3 className={dashboardStyles.cardTitle}>{host?.Name ?? 'Unknown Host'}</h3>
-        <div className={classNames(dashboardStyles.statusLabel, toneClass)}>
-          <StatusIcon name={meta.icon} className={dashboardStyles.statusIcon} />
-          <span>{label}</span>
+    <div className={dashboardStyles.logOverlay} role="presentation">
+      <div
+        className={dashboardStyles.logDialog}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="log-dialog-title"
+      >
+        <div className={dashboardStyles.logHeader}>
+          <div>
+            <h3 id="log-dialog-title" className={dashboardStyles.logTitle}>
+              {displayName}
+            </h3>
+            <p className={dashboardStyles.logSubtitle}>{hostName}</p>
+          </div>
+          <button
+            type="button"
+            className={dashboardStyles.closeButton}
+            onClick={onClose}
+            aria-label="Close log viewer"
+          >
+            ×
+          </button>
+        </div>
+        <div className={dashboardStyles.logTabs} role="tablist">
+          {tabs.map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              className={dashboardStyles.logTab}
+              role="tab"
+              aria-selected={activeTab === tab.key}
+              onClick={() => setActiveTab(tab.key)}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        <div className={dashboardStyles.logContent} role="tabpanel">
+          {tabState.error && (
+            <div className={dashboardStyles.logError} role="alert">
+              {tabState.error}
+            </div>
+          )}
+          {tabState.loading ? (
+            <p>Loading {logLabel} log…</p>
+          ) : (
+            <pre className={dashboardStyles.logPre}>
+              {tabState.content || `No ${logLabel} output.`}
+            </pre>
+          )}
+        </div>
+        <div className={dashboardStyles.logFooter}>
+          <div className={dashboardStyles.logStatus}>
+            {tabState.overflow
+              ? 'Showing the most recent log entries.'
+              : `Next offset: ${tabState.offset}`}
+          </div>
+          <div className={dashboardStyles.logFooterActions}>
+            <button
+              type="button"
+              className={`${ui.button} ${ui.buttonSecondary}`}
+              onClick={handleRefresh}
+              disabled={tabState.loading}
+            >
+              Refresh
+            </button>
+            <button
+              type="button"
+              className={`${ui.button} ${ui.buttonDanger}`}
+              onClick={handleClear}
+              disabled={clearing}
+            >
+              {clearing ? 'Clearing…' : 'Clear logs'}
+            </button>
+            <button
+              type="button"
+              className={`${ui.button} ${ui.buttonGhost}`}
+              onClick={onClose}
+            >
+              Close
+            </button>
+          </div>
         </div>
       </div>
     </div>
   );
 }
 
+function ProcessRow({ hostId, hostName, process, onProcessAction, onViewLogs }) {
+  const [pendingAction, setPendingAction] = useState(null);
+  const [actionError, setActionError] = useState(null);
+
+  const identifier = useMemo(() => formatProcessIdentifier(process), [process]);
+  const nameCandidate = process?.name ?? process?.processname ?? identifier;
+  const displayName =
+    typeof nameCandidate === 'string'
+      ? nameCandidate.trim() || 'Unknown service'
+      : nameCandidate || 'Unknown service';
+  const description = process?.description;
+  const status = process?.statename ?? 'CONERR';
+  const startSeconds = Number(process?.start);
+  const nowSeconds = Number(process?.now);
+  const pid = Number(process?.pid);
+
+  const uptime =
+    status === 'RUNNING' && Number.isFinite(startSeconds) && Number.isFinite(nowSeconds)
+      ? formatDuration(nowSeconds - startSeconds)
+      : null;
+  const startedAt = formatTimestamp(startSeconds);
+  const spawnError = typeof process?.spawnerr === 'string' ? process.spawnerr : null;
+
+  const handleAction = async (action) => {
+    if (!identifier || !action) {
+      return;
+    }
+
+    setPendingAction(action);
+    setActionError(null);
+    try {
+      await onProcessAction({ hostId, processName: identifier, action });
+    } catch (err) {
+      setActionError(err.message ?? 'Failed to control process.');
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  const canStart = ['STOPPED', 'EXITED', 'BACKOFF', 'FATAL'].includes(status);
+  const canStop = ['RUNNING', 'STARTING'].includes(status);
+  const disableStart = pendingAction !== null || !identifier || !canStart;
+  const disableStop = pendingAction !== null || !identifier || !canStop;
+  const disableRestart = pendingAction !== null || !identifier;
+  const disableLogs = !identifier || typeof onViewLogs !== 'function';
+
+  const metaParts = [];
+  if (Number.isFinite(pid) && pid > 0) {
+    metaParts.push(`PID ${pid}`);
+  }
+  if (uptime) {
+    metaParts.push(`Uptime ${uptime}`);
+  }
+  if (startedAt) {
+    metaParts.push(`Started ${startedAt}`);
+  }
+
+  return (
+    <tr>
+      <th scope="row">
+        <p className={dashboardStyles.processName}>{displayName}</p>
+        {description && <p className={dashboardStyles.processDescription}>{description}</p>}
+        {spawnError && (
+          <p className={dashboardStyles.processDescription}>Last error: {spawnError}</p>
+        )}
+        {metaParts.length > 0 && (
+          <div className={dashboardStyles.processMeta}>
+            {metaParts.map((item) => (
+              <span key={item}>{item}</span>
+            ))}
+          </div>
+        )}
+      </th>
+      <td className={dashboardStyles.statusCell}>
+        <StatusBadge status={status} />
+      </td>
+      <td className={dashboardStyles.uptimeCell}>{uptime ?? '—'}</td>
+      <td className={classNames(dashboardStyles.actionsCell, ui.tableCellNumeric)}>
+        <div className={ui.buttonGroup} role="group">
+          <button
+            type="button"
+            className={`${ui.button} ${ui.buttonSuccess}`}
+            disabled={disableStart}
+            onClick={() => handleAction('start')}
+          >
+            {pendingAction === 'start' ? 'Starting…' : 'Start'}
+          </button>
+          <button
+            type="button"
+            className={`${ui.button} ${ui.buttonDanger}`}
+            disabled={disableStop}
+            onClick={() => handleAction('stop')}
+          >
+            {pendingAction === 'stop' ? 'Stopping…' : 'Stop'}
+          </button>
+          <button
+            type="button"
+            className={`${ui.button} ${ui.buttonSecondary}`}
+            disabled={disableRestart}
+            onClick={() => handleAction('restart')}
+          >
+            {pendingAction === 'restart' ? 'Restarting…' : 'Restart'}
+          </button>
+          <button
+            type="button"
+            className={`${ui.button} ${ui.buttonGhost}`}
+            disabled={disableLogs}
+            onClick={() =>
+              onViewLogs?.({
+                hostId,
+                hostName,
+                processName: identifier,
+                displayName
+              })
+            }
+          >
+            View logs
+          </button>
+        </div>
+        {actionError && <div className={dashboardStyles.actionError}>{actionError}</div>}
+      </td>
+    </tr>
+  );
+}
+
+function HostPanel({ entry, onProcessAction, onViewLogs }) {
+  const { hostId, host, processes, error } = entry;
+  const hostName = host?.Name ?? hostId ?? 'Unknown host';
+  const groupName = host?.GroupName ?? null;
+  const hostUrl = isSafeUrl(host?.Url) ? host.Url : null;
+  const summary = summarizeProcesses(processes);
+  const summaryLabel = formatStatusLabel(summary.status);
+  const hostProcessCount = processes.length;
+  const processLabel =
+    summary.status === 'CONERR'
+      ? 'Unable to retrieve process list.'
+      : hostProcessCount === 0
+      ? 'No services reported.'
+      : `${hostProcessCount} ${hostProcessCount === 1 ? 'service' : 'services'}`;
+
+  return (
+    <article className={dashboardStyles.hostCard}>
+      <header className={dashboardStyles.hostHeader}>
+        <div>
+          <h3 className={dashboardStyles.hostTitle}>{hostName}</h3>
+          <div className={dashboardStyles.hostMeta}>
+            {groupName && <span>Group: {groupName}</span>}
+            {hostUrl && (
+              <a
+                href={hostUrl}
+                target="_blank"
+                rel="noreferrer"
+                className={dashboardStyles.hostMetaLink}
+              >
+                Open host
+              </a>
+            )}
+          </div>
+        </div>
+        <div className={dashboardStyles.hostStats}>
+          <StatusBadge status={summary.status}>{summaryLabel}</StatusBadge>
+          <span className={dashboardStyles.hostProcessCount}>{processLabel}</span>
+        </div>
+      </header>
+      <div className={dashboardStyles.hostBody}>
+        {error && (
+          <div className={`${ui.alert} ${ui.alertError} ${dashboardStyles.hostError}`} role="alert">
+            {error.message ?? 'Failed to communicate with supervisor.'}
+          </div>
+        )}
+        {processes.length === 0 ? (
+          <p className={dashboardStyles.emptyState}>No supervisor processes available.</p>
+        ) : (
+          <div className={ui.tableWrapper}>
+            <table className={ui.table}>
+              <thead>
+                <tr>
+                  <th scope="col">Service</th>
+                  <th scope="col">Status</th>
+                  <th scope="col">Uptime</th>
+                  <th scope="col" className={ui.tableCellNumeric}>
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {processes.map((process, index) => {
+                  const identifier = formatProcessIdentifier(process);
+                  const key = identifier || `${hostId}-${index}`;
+                  return (
+                    <ProcessRow
+                      key={key}
+                      hostId={hostId}
+                      hostName={hostName}
+                      process={process}
+                      onProcessAction={onProcessAction}
+                      onViewLogs={onViewLogs}
+                    />
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+
 export default function Dashboard() {
-  const { hosts, error, loading } = useDashboardData(10000);
-  const hasHosts = hosts.length > 0;
+  const { hostEntries, error, loading } = useSupervisorData(10000);
+  const [logViewer, setLogViewer] = useState(null);
+
+  const handleProcessAction = async ({ hostId, processName, action }) => {
+    if (!hostId || !processName || !action) {
+      throw new Error('Missing host, process or action.');
+    }
+
+    await requestJson('/api/v1/supervisors/control', {
+      method: 'POST',
+      body: JSON.stringify({ host: hostId, process: processName, action })
+    });
+  };
+
+  const handleViewLogs = (payload) => {
+    setLogViewer(payload);
+  };
+
+  const closeLogViewer = () => {
+    setLogViewer(null);
+  };
 
   return (
     <section className={dashboardStyles.section} aria-labelledby="dashboard-heading">
       <header className={ui.sectionHeaderLarge}>
         <h2 id="dashboard-heading" className={dashboardStyles.sectionTitle}>
-          Supervisor overview
+          Service dashboard
         </h2>
+        <p className={dashboardStyles.sectionSubtitle}>
+          Monitor Supervisor-managed services, restart processes, and inspect logs across every host.
+        </p>
       </header>
-      {loading && hosts.length === 0 && <p>Loading the latest supervisor information…</p>}
+      {loading && hostEntries.length === 0 && <p>Loading the latest supervisor information…</p>}
       {error && (
-        <div className={`${ui.alert} ${ui.alertError} ${dashboardStyles.error}`} role="alert">
+        <div className={`${ui.alert} ${ui.alertError}`} role="alert">
           {error}
         </div>
       )}
-      {!hasHosts && !loading && !error && <p>No hosts available.</p>}
-      {hasHosts && (
-        <div className={dashboardStyles.grid}>
-          {hosts.map((entry, index) => (
-            <HostCard
-              key={entry.host?.idHost ?? `${entry.host?.Name ?? 'host'}-${index}`}
-              host={entry.host}
-              processes={entry.data}
+      {!loading && hostEntries.length === 0 && !error && <p>No hosts available.</p>}
+      {hostEntries.length > 0 && (
+        <div className={dashboardStyles.hostList}>
+          {hostEntries.map((entry) => (
+            <HostPanel
+              key={entry.hostId}
+              entry={entry}
+              onProcessAction={handleProcessAction}
+              onViewLogs={handleViewLogs}
             />
           ))}
         </div>
+      )}
+      {logViewer && (
+        <ProcessLogDialog
+          open
+          hostId={logViewer.hostId}
+          hostName={logViewer.hostName}
+          processName={logViewer.processName}
+          displayName={logViewer.displayName}
+          onClose={closeLogViewer}
+        />
       )}
     </section>
   );

--- a/client/src/Dashboard.module.css
+++ b/client/src/Dashboard.module.css
@@ -1,87 +1,298 @@
 .section {
-  padding-bottom: 2rem;
-}
-
-.grid {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-}
-
-.card {
-  height: 100%;
-  text-align: center;
-  border-radius: var(--nv-radius-md);
-  background: var(--nv-color-surface);
-  box-shadow: var(--nv-shadow-md);
   display: flex;
   flex-direction: column;
-  justify-content: center;
-}
-
-.cardBody {
-  padding: 2rem 1.5rem;
-}
-
-.cardTitle {
-  font-size: 1.125rem;
-  font-weight: 600;
-  margin: 0 0 1.25rem;
-  color: var(--nv-color-secondary);
-}
-
-.statusLabel {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.75rem;
-  font-size: 2.5rem;
-  font-weight: 600;
-}
-
-.statusIcon {
-  width: 2.5rem;
-  height: 2.5rem;
-}
-
-.statusToneDanger {
-  color: #aa2700;
-}
-
-.statusToneSuccess {
-  color: var(--nv-color-success);
-}
-
-.statusToneInfo {
-  color: #1641c4;
-}
-
-.statusToneWarning {
-  color: var(--nv-color-warning);
+  gap: 1.75rem;
 }
 
 .sectionTitle {
+  margin: 0;
+  font-size: 1.9rem;
+}
+
+.sectionSubtitle {
+  margin: 0;
+  color: var(--nv-color-text-muted);
+  max-width: 60ch;
+}
+
+.hostList {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.hostCard {
+  background-color: #ffffff;
+  border-radius: var(--nv-radius-md, 14px);
+  box-shadow: var(--nv-shadow-md, 0 12px 24px rgba(15, 23, 42, 0.08));
+  padding: 1.75rem;
+}
+
+.hostHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.hostTitle {
+  margin: 0;
   font-size: 1.5rem;
+  color: var(--nv-color-secondary);
+}
+
+.hostMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+  color: var(--nv-color-text-muted);
+}
+
+.hostMetaLink {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.hostStats {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  align-items: flex-end;
+}
+
+.hostProcessCount {
+  font-size: 0.9rem;
+  color: var(--nv-color-text-muted);
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.95rem;
+}
+
+.statusIcon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.statusToneDanger {
+  background-color: rgba(199, 46, 28, 0.16);
+  color: #7f1d1d;
+}
+
+.statusToneSuccess {
+  background-color: rgba(17, 116, 74, 0.16);
+  color: #0f5132;
+}
+
+.statusToneInfo {
+  background-color: rgba(17, 63, 82, 0.12);
+  color: #103f52;
+}
+
+.statusToneWarning {
+  background-color: rgba(255, 177, 66, 0.2);
+  color: #92400e;
+}
+
+.hostBody {
+  margin-top: 1.5rem;
+}
+
+.processName {
   font-weight: 600;
   margin: 0;
   color: var(--nv-color-secondary);
 }
 
-.error {
-  margin: 1rem 0;
+.processDescription {
+  margin: 0.3rem 0 0;
+  font-size: 0.9rem;
+  color: var(--nv-color-text-muted);
 }
 
-@media (max-width: 575px) {
-  .cardBody {
-    padding: 1.5rem 1.25rem;
+.processMeta {
+  display: flex;
+  gap: 1rem;
+  margin-top: 0.35rem;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  color: var(--nv-color-text-muted);
+}
+
+.statusCell {
+  white-space: nowrap;
+}
+
+.uptimeCell {
+  font-size: 0.95rem;
+  color: var(--nv-color-text-muted);
+  white-space: nowrap;
+}
+
+.actionsCell {
+  text-align: right;
+}
+
+.actionsCell .buttonGroup {
+  justify-content: flex-end;
+}
+
+.actionError {
+  margin-top: 0.5rem;
+  color: var(--nv-color-danger);
+  font-size: 0.85rem;
+}
+
+.emptyState {
+  color: var(--nv-color-text-muted);
+  margin: 0;
+}
+
+.hostError {
+  margin-bottom: 1rem;
+}
+
+.logOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 60;
+}
+
+.logDialog {
+  background: #ffffff;
+  border-radius: var(--nv-radius-md, 14px);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.22);
+  width: min(900px, 100%);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.logHeader {
+  padding: 1.5rem 1.5rem 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.logTitle {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.logSubtitle {
+  margin: 0.4rem 0 0;
+  font-size: 0.95rem;
+  color: var(--nv-color-text-muted);
+}
+
+.logTabs {
+  display: flex;
+  gap: 0.5rem;
+  padding: 1rem 1.5rem 0.5rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.12);
+}
+
+.logTab {
+  border: none;
+  background: none;
+  font-weight: 600;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--nv-radius-sm);
+  cursor: pointer;
+  color: var(--nv-color-text-muted);
+}
+
+.logTab[aria-selected='true'] {
+  background: rgba(17, 63, 82, 0.1);
+  color: var(--nv-color-secondary);
+}
+
+.logContent {
+  padding: 1rem 1.5rem;
+  overflow-y: auto;
+  flex: 1;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+.logPre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: ui-monospace, SFMono-Regular, SFMono, Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.logFooter {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.5rem 1.5rem;
+}
+
+.logFooterActions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.logStatus {
+  font-size: 0.85rem;
+  color: var(--nv-color-text-muted);
+}
+
+.logError {
+  color: #fca5a5;
+  font-size: 0.9rem;
+  margin-bottom: 0.75rem;
+}
+
+.closeButton {
+  border: none;
+  background: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--nv-color-text-muted);
+}
+
+.closeButton:hover,
+.closeButton:focus-visible {
+  color: var(--nv-color-secondary);
+}
+
+@media (max-width: 720px) {
+  .hostHeader {
+    flex-direction: column;
+    align-items: stretch;
   }
 
-  .statusLabel {
-    font-size: 2rem;
+  .hostStats {
+    align-items: flex-start;
   }
 
-  .statusIcon {
-    width: 2rem;
-    height: 2rem;
+  .actionsCell {
+    text-align: left;
+  }
+
+  .actionsCell .buttonGroup {
+    justify-content: flex-start;
   }
 }

--- a/client/src/pages/OverviewPage.jsx
+++ b/client/src/pages/OverviewPage.jsx
@@ -1,0 +1,66 @@
+import { StatusIcon, STATUS_META, summarizeProcesses, useSupervisorData } from '../supervisorData.jsx';
+import styles from '../styles/OverviewPage.module.css';
+import ui from '../styles/ui.module.css';
+
+const STATUS_TONE_CLASS = {
+  danger: styles.statusToneDanger,
+  success: styles.statusToneSuccess,
+  info: styles.statusToneInfo,
+  warning: styles.statusToneWarning
+};
+
+function classNames(...values) {
+  return values.filter(Boolean).join(' ');
+}
+
+function HostCard({ host, processes }) {
+  const summary = summarizeProcesses(processes);
+  const meta = STATUS_META[summary.status] ?? STATUS_META.CONERR;
+  const label = summary.count;
+  const toneClass = STATUS_TONE_CLASS[meta.tone] ?? styles.statusToneInfo;
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.cardBody}>
+        <h3 className={styles.cardTitle}>{host?.Name ?? 'Unknown Host'}</h3>
+        <div className={classNames(styles.statusLabel, toneClass)}>
+          <StatusIcon name={meta.icon} className={styles.statusIcon} />
+          <span>{label}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function OverviewPage() {
+  const { groupedHosts, error, loading } = useSupervisorData(10000);
+  const hasHosts = groupedHosts.length > 0;
+
+  return (
+    <section className={styles.section} aria-labelledby="overview-heading">
+      <header className={ui.sectionHeaderLarge}>
+        <h2 id="overview-heading" className={styles.sectionTitle}>
+          Supervisor overview
+        </h2>
+      </header>
+      {loading && groupedHosts.length === 0 && <p>Loading the latest supervisor information…</p>}
+      {error && (
+        <div className={`${ui.alert} ${ui.alertError} ${styles.error}`} role="alert">
+          {error}
+        </div>
+      )}
+      {!hasHosts && !loading && !error && <p>No hosts available.</p>}
+      {hasHosts && (
+        <div className={styles.grid}>
+          {groupedHosts.map((entry, index) => (
+            <HostCard
+              key={entry.host?.idHost ?? `${entry.host?.Name ?? 'host'}-${index}`}
+              host={entry.host}
+              processes={entry.data}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/client/src/styles/OverviewPage.module.css
+++ b/client/src/styles/OverviewPage.module.css
@@ -1,0 +1,87 @@
+.section {
+  padding-bottom: 2rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+.card {
+  height: 100%;
+  text-align: center;
+  border-radius: var(--nv-radius-md);
+  background: var(--nv-color-surface);
+  box-shadow: var(--nv-shadow-md);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.cardBody {
+  padding: 2rem 1.5rem;
+}
+
+.cardTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 0 0 1.25rem;
+  color: var(--nv-color-secondary);
+}
+
+.statusLabel {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  font-size: 2.5rem;
+  font-weight: 600;
+}
+
+.statusIcon {
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
+.statusToneDanger {
+  color: #aa2700;
+}
+
+.statusToneSuccess {
+  color: var(--nv-color-success);
+}
+
+.statusToneInfo {
+  color: #1641c4;
+}
+
+.statusToneWarning {
+  color: var(--nv-color-warning);
+}
+
+.sectionTitle {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+  color: var(--nv-color-secondary);
+}
+
+.error {
+  margin: 1rem 0;
+}
+
+@media (max-width: 575px) {
+  .cardBody {
+    padding: 1.5rem 1.25rem;
+  }
+
+  .statusLabel {
+    font-size: 2rem;
+  }
+
+  .statusIcon {
+    width: 2rem;
+    height: 2rem;
+  }
+}

--- a/client/src/supervisorData.jsx
+++ b/client/src/supervisorData.jsx
@@ -1,0 +1,451 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+export const STATUS_ORDER = ['CONERR', 'FATAL', 'EXITED', 'STARTING', 'RUNNING', 'STOPPED', 'BACKOFF'];
+
+export const STATUS_META = {
+  CONERR: { tone: 'danger', icon: 'bolt' },
+  FATAL: { tone: 'danger', icon: 'alert' },
+  EXITED: { tone: 'danger', icon: 'alert' },
+  STARTING: { tone: 'warning', icon: 'refresh' },
+  RUNNING: { tone: 'success', icon: 'check' },
+  STOPPED: { tone: 'info', icon: 'pause' },
+  BACKOFF: { tone: 'info', icon: 'pause' }
+};
+
+function classNames(...values) {
+  return values.filter(Boolean).join(' ');
+}
+
+export function StatusIcon({ name, className }) {
+  switch (name) {
+    case 'bolt':
+      return (
+        <svg className={className} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            fill="currentColor"
+            d="M11.25 2.25a.75.75 0 01.654.37l4.5 7.5a.75.75 0 01-.654 1.13H12v8.5a.75.75 0 01-1.404.36l-4.5-7.5A.75.75 0 016.75 11H10V2.75a.75.75 0 01.75-.75z"
+          />
+        </svg>
+      );
+    case 'alert':
+      return (
+        <svg className={className} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            fill="currentColor"
+            d="M12 2a10 10 0 1010 10A10 10 0 0012 2zm0 5a1 1 0 01.993.883L13 8v5a1 1 0 01-1.993.117L11 13V8a1 1 0 011-1zm0 9.25a1.25 1.25 0 11-1.25 1.25A1.25 1.25 0 0112 16.25z"
+          />
+        </svg>
+      );
+    case 'refresh':
+      return (
+        <svg className={className} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            fill="currentColor"
+            d="M3.978 8.223a9 9 0 0114.962-3.74V3.75a.75.75 0 011.5 0v4.5a.75.75 0 01-.75.75h-4.5a.75.75 0 010-1.5h2.385a7.5 7.5 0 10.748 7.105.75.75 0 111.318.75A9 9 0 113.978 8.223z"
+          />
+        </svg>
+      );
+    case 'check':
+      return (
+        <svg className={className} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            fill="currentColor"
+            d="M12 2a10 10 0 1010 10A10 10 0 0012 2zm4.28 7.22l-5 5a.75.75 0 01-1.06 0l-2-2a.75.75 0 111.06-1.06L11 12.94l4.22-4.22a.75.75 0 111.06 1.06z"
+          />
+        </svg>
+      );
+    case 'pause':
+    default:
+      return (
+        <svg className={className} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path
+            fill="currentColor"
+            d="M12 2a10 10 0 1010 10A10 10 0 0012 2zm-2.25 5.75a.75.75 0 00-.75.75v7a.75.75 0 001.5 0v-7a.75.75 0 00-.75-.75zm4.5 0a.75.75 0 00-.75.75v7a.75.75 0 001.5 0v-7a.75.75 0 00-.75-.75z"
+          />
+        </svg>
+      );
+  }
+}
+
+export function summarizeProcesses(processes) {
+  if (!Array.isArray(processes) || processes.some((proc) => proc && proc.errno)) {
+    return { status: 'CONERR', count: 'NA' };
+  }
+
+  const counts = new Map();
+  for (const proc of processes) {
+    const status = proc?.statename;
+    if (!status) {
+      continue;
+    }
+    counts.set(status, (counts.get(status) ?? 0) + 1);
+  }
+
+  if (counts.size === 0) {
+    return { status: 'CONERR', count: 'NA' };
+  }
+
+  const [status, count] = [...counts.entries()].sort(
+    ([statusA], [statusB]) => STATUS_ORDER.indexOf(statusA) - STATUS_ORDER.indexOf(statusB)
+  )[0];
+
+  return { status, count };
+}
+
+function normalizeHostEntries(hostMap) {
+  const entries = [];
+  for (const [hostId, entry] of hostMap.entries()) {
+    const host = entry?.host ?? null;
+    let processes = [];
+    let processError = null;
+
+    if (Array.isArray(entry?.data)) {
+      processes = entry.data;
+    } else if (entry?.data && entry.data.errno) {
+      processError = entry.data;
+    } else if (entry?.data) {
+      processes = [entry.data];
+    }
+
+    const error = entry?.error ?? (processError ? serializeProcessError(processError) : null);
+
+    entries.push({
+      hostId,
+      host,
+      processes,
+      processError,
+      error,
+      raw: entry
+    });
+  }
+
+  return entries.sort((a, b) => {
+    const groupA = (a.host?.GroupName ?? '').toString().toLowerCase();
+    const groupB = (b.host?.GroupName ?? '').toString().toLowerCase();
+    if (groupA !== groupB) {
+      return groupA.localeCompare(groupB);
+    }
+
+    const nameA = (a.host?.Name ?? a.hostId ?? '').toString().toLowerCase();
+    const nameB = (b.host?.Name ?? b.hostId ?? '').toString().toLowerCase();
+    return nameA.localeCompare(nameB);
+  });
+}
+
+function serializeProcessError(error) {
+  if (!error || typeof error !== 'object') {
+    return { message: 'Supervisor connection error' };
+  }
+
+  if (typeof error.errmsg === 'string') {
+    return { message: error.errmsg };
+  }
+
+  if (typeof error.message === 'string') {
+    return { message: error.message };
+  }
+
+  return { message: 'Supervisor connection error' };
+}
+
+function transformHosts(rawHosts) {
+  const entries = Object.entries(rawHosts ?? {}).sort(([a], [b]) => a.localeCompare(b));
+  const grouped = new Map();
+
+  for (const [, value] of entries) {
+    if (!value || !value.host) {
+      continue;
+    }
+
+    const { host, data = [] } = value;
+    const groupName = host.GroupName;
+
+    if (groupName) {
+      const existing = grouped.get(groupName);
+      if (existing) {
+        existing.data = existing.data.concat(Array.isArray(data) ? data : []);
+      } else {
+        grouped.set(groupName, {
+          host: { Name: groupName },
+          data: Array.isArray(data) ? [...data] : []
+        });
+      }
+    } else {
+      const key = host.Name ?? '';
+      if (!grouped.has(key)) {
+        grouped.set(key, {
+          host,
+          data: Array.isArray(data) ? data : data && data.errno ? [data] : []
+        });
+      } else {
+        const existing = grouped.get(key);
+        existing.data = existing.data.concat(Array.isArray(data) ? data : []);
+      }
+    }
+  }
+
+  return Array.from(grouped.values());
+}
+
+function normalizeRawHosts(rawHosts) {
+  if (!rawHosts || typeof rawHosts !== 'object') {
+    return new Map();
+  }
+
+  return new Map(Object.entries(rawHosts));
+}
+
+export function useSupervisorData(pollIntervalMs = 10000) {
+  const [hostEntries, setHostEntries] = useState([]);
+  const [groupedHosts, setGroupedHosts] = useState([]);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const initialLoad = useRef(true);
+  const hostState = useRef(new Map());
+  const controllerRef = useRef(null);
+  const fallbackTimerRef = useRef(null);
+  const eventSourceRef = useRef(null);
+  const reconnectTimerRef = useRef(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fallbackInterval = Math.max(Number(pollIntervalMs) || 0, 60000);
+
+    const applyHostMap = (hostMap) => {
+      hostState.current = hostMap;
+      setHostEntries(normalizeHostEntries(hostState.current));
+      setGroupedHosts(transformHosts(Object.fromEntries(hostState.current)));
+      if (initialLoad.current) {
+        setLoading(false);
+        initialLoad.current = false;
+      }
+    };
+
+    const applyRawHosts = (rawHosts) => {
+      const normalized = normalizeRawHosts(rawHosts);
+      applyHostMap(normalized);
+    };
+
+    const applyUpdatePayload = (payload) => {
+      const current = new Map(hostState.current);
+      if (payload?.updates && typeof payload.updates === 'object') {
+        for (const [hostId, entry] of Object.entries(payload.updates)) {
+          current.set(hostId, entry);
+        }
+      }
+      if (Array.isArray(payload?.removed)) {
+        for (const hostId of payload.removed) {
+          current.delete(hostId);
+        }
+      }
+
+      applyHostMap(current);
+    };
+
+    const clearFallbackTimer = () => {
+      if (fallbackTimerRef.current) {
+        clearTimeout(fallbackTimerRef.current);
+        fallbackTimerRef.current = null;
+      }
+    };
+
+    const scheduleFallbackFetch = () => {
+      clearFallbackTimer();
+      fallbackTimerRef.current = setTimeout(() => {
+        performFetch({ showLoading: false, scheduleNext: true });
+      }, fallbackInterval);
+      if (typeof fallbackTimerRef.current?.unref === 'function') {
+        fallbackTimerRef.current.unref();
+      }
+    };
+
+    const performFetch = async ({ showLoading, scheduleNext } = {}) => {
+      if (cancelled) {
+        return;
+      }
+
+      if (showLoading && initialLoad.current) {
+        setLoading(true);
+      }
+
+      if (controllerRef.current) {
+        controllerRef.current.abort();
+      }
+
+      const controller = new AbortController();
+      controllerRef.current = controller;
+
+      try {
+        const response = await fetch('/api/v1/supervisors', {
+          headers: { Accept: 'application/json' },
+          signal: controller.signal,
+          credentials: 'same-origin'
+        });
+
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+
+        const payload = await response.json();
+        if (cancelled) {
+          return;
+        }
+
+        applyRawHosts(payload?.data);
+        setError(null);
+      } catch (err) {
+        if (cancelled || err.name === 'AbortError') {
+          return;
+        }
+        setError(err.message ?? 'Failed to load supervisor data.');
+      } finally {
+        if (scheduleNext && !cancelled) {
+          scheduleFallbackFetch();
+        }
+      }
+    };
+
+    const clearReconnectTimer = () => {
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+    };
+
+    const startStream = () => {
+      if (cancelled) {
+        return;
+      }
+
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current = null;
+      }
+
+      const source = new EventSource('/api/v1/supervisors/stream');
+      eventSourceRef.current = source;
+
+      source.onopen = () => {
+        setError(null);
+      };
+
+      source.addEventListener('snapshot', (event) => {
+        try {
+          const payload = JSON.parse(event.data);
+          applyRawHosts(payload);
+          setError(null);
+        } catch (_err) {
+          setError('Received malformed supervisor snapshot.');
+        }
+      });
+
+      source.addEventListener('update', (event) => {
+        try {
+          const payload = JSON.parse(event.data);
+          applyUpdatePayload(payload);
+          setError(null);
+        } catch (_err) {
+          setError('Received malformed supervisor update.');
+        }
+      });
+
+      source.onerror = () => {
+        if (cancelled) {
+          return;
+        }
+
+        setError((current) => current ?? 'Reconnecting to supervisor stream…');
+
+        if (source.readyState === EventSource.CLOSED && !reconnectTimerRef.current) {
+          reconnectTimerRef.current = setTimeout(() => {
+            reconnectTimerRef.current = null;
+            startStream();
+          }, 3000);
+        }
+      };
+    };
+
+    performFetch({ showLoading: true, scheduleNext: true });
+    startStream();
+
+    return () => {
+      cancelled = true;
+      if (controllerRef.current) {
+        controllerRef.current.abort();
+        controllerRef.current = null;
+      }
+      clearFallbackTimer();
+      clearReconnectTimer();
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current = null;
+      }
+    };
+  }, [pollIntervalMs]);
+
+  const value = useMemo(
+    () => ({ hostEntries, groupedHosts, error, loading }),
+    [hostEntries, groupedHosts, error, loading]
+  );
+
+  return value;
+}
+
+export function formatProcessIdentifier(process) {
+  if (!process || typeof process !== 'object') {
+    return '';
+  }
+
+  const name = process.name ?? process.processname ?? process.Program ?? process.command ?? '';
+  const group = process.group ?? process.Group ?? '';
+
+  if (name && group && group !== name) {
+    return `${group}:${name}`;
+  }
+
+  return name || group || '';
+}
+
+export function formatTimestamp(seconds) {
+  const value = Number(seconds);
+  if (!Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+
+  try {
+    return new Date(value * 1000).toLocaleString();
+  } catch {
+    return null;
+  }
+}
+
+export function formatDuration(seconds) {
+  let remaining = Math.floor(Number(seconds));
+  if (!Number.isFinite(remaining) || remaining <= 0) {
+    return null;
+  }
+
+  const parts = [];
+  const units = [
+    ['d', 86400],
+    ['h', 3600],
+    ['m', 60],
+    ['s', 1]
+  ];
+
+  for (const [suffix, value] of units) {
+    if (remaining < value) {
+      continue;
+    }
+
+    const amount = Math.floor(remaining / value);
+    remaining -= amount * value;
+    parts.push(`${amount}${suffix}`);
+
+    if (parts.length >= 2) {
+      break;
+    }
+  }
+
+  return parts.length > 0 ? parts.join(' ') : null;
+}


### PR DESCRIPTION
## Summary
- restore the detailed service dashboard with per-process controls, log viewer, and updated styling
- share supervisor polling logic through a reusable hook and move the previous card grid into an Overview page
- update navigation to expose the new Overview route while keeping the service dashboard as the default landing view

## Testing
- npm test -- --runTestsByPath __tests__/client/adminPages.test.jsx *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a02185f0832ea4f6e1ce33ad5dd6