### PR TITLE
Ensure dashboard SSE uses credentialed EventSource

### DIFF
--- a/client/__tests__/createEventSource.test.js
+++ b/client/__tests__/createEventSource.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
+
+import { createEventSource } from '../src/utils/createEventSource.js';
+
+describe('createEventSource', () => {
+  let originalEventSource;
+
+  beforeEach(() => {
+    originalEventSource = global.EventSource;
+  });
+
+  afterEach(() => {
+    if (originalEventSource === undefined) {
+      delete global.EventSource;
+    } else {
+      global.EventSource = originalEventSource;
+    }
+  });
+
+  it('creates an EventSource with credentials when supported', () => {
+    const instance = { readyState: 0 };
+    const eventSourceMock = jest.fn(() => instance);
+    global.EventSource = eventSourceMock;
+
+    const result = createEventSource('/api/v1/supervisors/stream');
+
+    expect(result).toBe(instance);
+    expect(eventSourceMock).toHaveBeenCalledTimes(1);
+    expect(eventSourceMock).toHaveBeenCalledWith('/api/v1/supervisors/stream', {
+      withCredentials: true
+    });
+  });
+
+  it('falls back to the legacy constructor signature when credentials options are not supported', () => {
+    const instance = { readyState: 0 };
+    const eventSourceMock = jest
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new TypeError('Options argument is not supported');
+      })
+      .mockImplementation(() => instance);
+
+    global.EventSource = eventSourceMock;
+
+    const result = createEventSource('/api/v1/supervisors/stream');
+
+    expect(result).toBe(instance);
+    expect(eventSourceMock).toHaveBeenCalledTimes(2);
+    expect(eventSourceMock).toHaveBeenNthCalledWith(1, '/api/v1/supervisors/stream', {
+      withCredentials: true
+    });
+    expect(eventSourceMock).toHaveBeenNthCalledWith(2, '/api/v1/supervisors/stream');
+  });
+
+  it('throws a descriptive error when EventSource is unavailable', () => {
+    delete global.EventSource;
+
+    expect(() => createEventSource('/api/v1/supervisors/stream')).toThrow(
+      'EventSource is not supported in this environment'
+    );
+  });
+});

--- a/client/src/Dashboard.jsx
+++ b/client/src/Dashboard.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import dashboardStyles from './Dashboard.module.css';
 import ui from './styles/ui.module.css';
+import { createEventSource } from './utils/createEventSource.js';
 
 const STATUS_ORDER = ['CONERR', 'FATAL', 'EXITED', 'STARTING', 'RUNNING', 'STOPPED', 'BACKOFF'];
 const STATUS_META = {
@@ -266,7 +267,7 @@ function useDashboardData(pollInterval) {
         eventSourceRef.current = null;
       }
 
-      const source = new EventSource('/api/v1/supervisors/stream');
+      const source = createEventSource('/api/v1/supervisors/stream');
       eventSourceRef.current = source;
 
       source.onopen = () => {

--- a/client/src/utils/createEventSource.js
+++ b/client/src/utils/createEventSource.js
@@ -1,0 +1,11 @@
+export function createEventSource(url) {
+  if (typeof EventSource !== 'function') {
+    throw new Error('EventSource is not supported in this environment');
+  }
+
+  try {
+    return new EventSource(url, { withCredentials: true });
+  } catch (_err) {
+    return new EventSource(url);
+  }
+}


### PR DESCRIPTION
## Summary
- add a utility that always opens the supervisor EventSource with credentials and falls back when unsupported
- update the dashboard stream subscription to use the utility so cookies are included with the request
- cover the utility with unit tests to verify the credential and fallback behaviour

## Testing
- npm test -- --runTestsByPath client/__tests__/createEventSource.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d6a33a1ff4832e9d5ebf7946b0b4cd