### PR TITLE
Delay supervisor stream until initial fetch completes

### DIFF
--- a/client/src/supervisorData.jsx
+++ b/client/src/supervisorData.jsx
@@ -365,8 +365,11 @@ export function useSupervisorData(pollIntervalMs = 10000) {
       };
     };
 
-    performFetch({ showLoading: true, scheduleNext: true });
-    startStream();
+    performFetch({ showLoading: true, scheduleNext: true }).finally(() => {
+      if (!cancelled) {
+        startStream();
+      }
+    });
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
## Summary
- wait for the initial supervisors API fetch to settle before opening the EventSource stream
- avoid starting the stream when the component has already unmounted

## Testing
- npm test -- --runTestsByPath __tests__/app.test.js *(fails: SyntaxError: The requested module '../shared/roles.js' does not provide an export named 'ROLE_ADMIN')*

------
https://chatgpt.com/codex/tasks/task_e_68d6a71bd940832eb46f1323d9a0a7fa