### PR TITLE
Add PID and started columns to dashboard table

### DIFF
--- a/client/src/Dashboard.jsx
+++ b/client/src/Dashboard.jsx
@@ -496,7 +496,6 @@ function ProcessRow({ hostId, hostName, process, onProcessAction, onViewLogs }) 
     typeof nameCandidate === 'string'
       ? nameCandidate.trim() || 'Unknown service'
       : nameCandidate || 'Unknown service';
-  const description = process?.description;
   const status = process?.statename ?? 'CONERR';
   const startSeconds = Number(process?.start);
   const nowSeconds = Number(process?.now);
@@ -532,37 +531,22 @@ function ProcessRow({ hostId, hostName, process, onProcessAction, onViewLogs }) 
   const disableRestart = pendingAction !== null || !identifier;
   const disableLogs = !identifier || typeof onViewLogs !== 'function';
 
-  const metaParts = [];
-  if (Number.isFinite(pid) && pid > 0) {
-    metaParts.push(`PID ${pid}`);
-  }
-  if (uptime) {
-    metaParts.push(`Uptime ${uptime}`);
-  }
-  if (startedAt) {
-    metaParts.push(`Started ${startedAt}`);
-  }
+  const pidDisplay = Number.isFinite(pid) && pid > 0 ? pid : '—';
 
   return (
     <tr>
       <th scope="row">
         <p className={dashboardStyles.processName}>{displayName}</p>
-        {description && <p className={dashboardStyles.processDescription}>{description}</p>}
         {spawnError && (
           <p className={dashboardStyles.processDescription}>Last error: {spawnError}</p>
         )}
-        {metaParts.length > 0 && (
-          <div className={dashboardStyles.processMeta}>
-            {metaParts.map((item) => (
-              <span key={item}>{item}</span>
-            ))}
-          </div>
-        )}
       </th>
+      <td className={dashboardStyles.pidCell}>{pidDisplay}</td>
       <td className={dashboardStyles.statusCell}>
         <StatusBadge status={status} />
       </td>
       <td className={dashboardStyles.uptimeCell}>{uptime ?? '—'}</td>
+      <td className={dashboardStyles.startedCell}>{startedAt ?? '—'}</td>
       <td className={classNames(dashboardStyles.actionsCell, ui.tableCellNumeric)}>
         <div className={ui.buttonGroup} role="group">
           <button
@@ -664,8 +648,10 @@ function HostPanel({ entry, onProcessAction, onViewLogs }) {
               <thead>
                 <tr>
                   <th scope="col">Service</th>
+                  <th scope="col">PID</th>
                   <th scope="col">Status</th>
                   <th scope="col">Uptime</th>
+                  <th scope="col">Started</th>
                   <th scope="col" className={ui.tableCellNumeric}>
                     Actions
                   </th>

--- a/client/src/Dashboard.module.css
+++ b/client/src/Dashboard.module.css
@@ -137,6 +137,18 @@
   white-space: nowrap;
 }
 
+.pidCell {
+  font-size: 0.95rem;
+  color: var(--nv-color-text-muted);
+  white-space: nowrap;
+}
+
+.startedCell {
+  font-size: 0.95rem;
+  color: var(--nv-color-text-muted);
+  white-space: nowrap;
+}
+
 .actionsCell {
   text-align: right;
 }


### PR DESCRIPTION
## Summary
- add a dedicated PID column to the dashboard process table and surface parsed process info in-table
- expose the process start timestamp in its own column and drop the duplicated description/meta rows

## Testing
- npm test -- --watch=false *(fails: SyntaxError: The requested module '../shared/roles.js' does not provide an export named 'ROLE_ADMIN')*

------
https://chatgpt.com/codex/tasks/task_e_68d6ae6a0034832e9a6eb6707aec43a2