### PR TITLE
Ensure log viewer sticks to bottom during auto refresh

### DIFF
--- a/client/src/Dashboard.jsx
+++ b/client/src/Dashboard.jsx
@@ -289,9 +289,7 @@ function ProcessLogDialog({ open, hostId, hostName, processName, displayName, on
       if (!node) {
         return;
       }
-      if (!isScrolledToBottom(node)) {
-        node.scrollTop = node.scrollHeight;
-      }
+      node.scrollTop = node.scrollHeight;
     });
   }, [logState, activeTab, open]);
 


### PR DESCRIPTION
## Summary
- ensure the log viewer always scrolls to the bottom after appending new log content when auto-refresh is active

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6b1af6904832e8a6b737975214555