### PR TITLE
Ensure log viewer stays pinned after appending logs

### DIFF
--- a/client/src/Dashboard.jsx
+++ b/client/src/Dashboard.jsx
@@ -69,8 +69,12 @@ function StatusBadge({ status, children }) {
 const SCROLL_STICKY_EPSILON_PX = 2;
 
 function isScrolledToBottom(node) {
+  if (node.scrollHeight <= node.clientHeight) {
+    return true;
+  }
+
   const distanceFromBottom = node.scrollHeight - node.scrollTop - node.clientHeight;
-  return Math.abs(distanceFromBottom) <= SCROLL_STICKY_EPSILON_PX;
+  return distanceFromBottom <= SCROLL_STICKY_EPSILON_PX;
 }
 
 function createLogState() {


### PR DESCRIPTION
## Summary
- treat non-scrollable log containers as already at the bottom
- relax the bottom check so appended log data keeps the viewport pinned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b77f01f0832ea30903dc4345ccb5