### PR TITLE
Add confirmation prompt before clearing process logs

### DIFF
--- a/client/src/Dashboard.jsx
+++ b/client/src/Dashboard.jsx
@@ -346,6 +346,16 @@ function ProcessLogDialog({ open, hostId, hostName, processName, displayName, on
   };
 
   const handleClear = async () => {
+    if (typeof window !== 'undefined') {
+      const confirmed = window.confirm(
+        'This will clear the server-side logs. Are you sure you want to continue?'
+      );
+
+      if (!confirmed) {
+        return;
+      }
+    }
+
     setClearing(true);
     try {
       await requestJson('/api/v1/supervisors/logs/clear', {


### PR DESCRIPTION
## Summary
- add a confirmation prompt before clearing process logs to warn that the action clears server-side logs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6bac461cc832ea64c51d9a91ed412