### PR TITLE
Add optional health check endpoint

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -6,6 +6,9 @@ ENV=development
 HOST=127.0.0.1
 PORT=3000
 
+# Enable the optional /health endpoint when set to true
+# HEALTH_ENDPOINT_ENABLED=true
+
 # Session configuration
 SESSION_SECRET=replace-with-a-long-random-string
 SESSION_COOKIE_NAME=nv.sid

--- a/README.md
+++ b/README.md
@@ -81,13 +81,17 @@ The session store uses the same connection details by default, but you can overr
 
   4. Navigate to the users page using the top menu. Change the admin credentials or add a new user and remove them.
 
-  5. Navigate to the hosts page using the top menu. Then add a host running supervisord using the form. Your supervisord config on each host should be set up to allow the xmlrpc interface over a inet port.
+ 5. Navigate to the hosts page using the top menu. Then add a host running supervisord using the form. Your supervisord config on each host should be set up to allow the xmlrpc interface over a inet port.
   For instance:
 
       [inet_http_server]
       port = *:9009 ;
 
   At this point, navigating back to the home page should show you a list of your hosts, and the processes running on them.
+
+### Health check endpoint
+
+Set `HEALTH_ENDPOINT_ENABLED=true` in your environment to expose a lightweight JSON health check at `/health`. When enabled the endpoint reports the server's uptime, last restart timestamp, CPU usage, and memory consumption. Leave the variable unset (or set it to `false`) to keep the endpoint disabled.
 
 ### Running behind an Apache reverse proxy
 

--- a/config.js
+++ b/config.js
@@ -152,7 +152,8 @@ const envSchema = z
     DASHBOARD_MANIFESTS: z.string().optional(),
     HOST_REFRESH_INTERVAL_MS: integerLike(),
     TRUST_PROXY: trustProxyLike(),
-    AUTH_ALLOW_SELF_REGISTRATION: booleanLike
+    AUTH_ALLOW_SELF_REGISTRATION: booleanLike,
+    HEALTH_ENDPOINT_ENABLED: booleanLike
   })
   .passthrough();
 
@@ -174,6 +175,7 @@ const sessionCookieName = parsedEnv.SESSION_COOKIE_NAME ?? 'nv.sid';
 
 const trustProxy = parsedEnv.TRUST_PROXY;
 const authAllowSelfRegistration = parsedEnv.AUTH_ALLOW_SELF_REGISTRATION ?? false;
+const healthCheckEnabled = parsedEnv.HEALTH_ENDPOINT_ENABLED ?? false;
 
 const defaultDbFilename = path.join(projectRoot, 'nodervisor.sqlite');
 const dbClient = parsedEnv.DB_CLIENT ?? 'sqlite3';
@@ -227,6 +229,10 @@ const dashboardConfig = createDashboardConfig({
   publicPath: parsedEnv.DASHBOARD_PUBLIC_PATH,
   entry: parsedEnv.DASHBOARD_ENTRY,
   manifestList: parsedEnv.DASHBOARD_MANIFESTS
+});
+
+const healthCheckConfig = Object.freeze({
+  enabled: healthCheckEnabled
 });
 
 class HostCache {
@@ -360,6 +366,7 @@ const config = {
   sessionSecret,
   supervisord,
   dashboard: dashboardConfig,
+  healthCheck: healthCheckConfig,
   auth: {
     allowSelfRegistration: authAllowSelfRegistration
   },

--- a/server/app.js
+++ b/server/app.js
@@ -12,6 +12,7 @@ import csurf from 'csurf';
 import { fileURLToPath } from 'node:url';
 
 import { createRouter } from '../routes/index.js';
+import { collectRuntimeMetrics } from './runtimeMetrics.js';
 
 /** @typedef {import('./types.js').ServerContext} ServerContext */
 
@@ -42,6 +43,15 @@ export function createApp(context) {
   app.use(methodOverride('_method'));
   app.use(cookieParser());
   app.use(helmet());
+
+  if (config.healthCheck?.enabled) {
+    app.get('/health', (req, res) => {
+      const metrics = collectRuntimeMetrics();
+      res.set('Cache-Control', 'no-store');
+      res.json({ status: 'ok', data: metrics });
+    });
+  }
+
   app.use(
     session({
       name: config.session.name,

--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,7 @@ import supervisordapi from 'supervisord';
 import config from '../config.js';
 import { createApp } from './app.js';
 import { createServerContext } from './context.js';
+import { markRuntimeStart } from './runtimeMetrics.js';
 
 const db = Knex(config.db);
 const knexsessions = Knex(config.sessionstore);
@@ -46,6 +47,7 @@ export async function start() {
     serverInstance = await new Promise((resolve, reject) => {
       const server = app.listen(app.get('port'), app.get('host'));
       server.once('listening', () => {
+        markRuntimeStart();
         console.log(`Nodervisor launched on ${app.get('host')}:${app.get('port')}`);
         resolve(server);
       });

--- a/server/runtimeMetrics.js
+++ b/server/runtimeMetrics.js
@@ -1,0 +1,55 @@
+import os from 'node:os';
+
+let lastRestartAt = new Date();
+let cpuBaseline = process.cpuUsage();
+
+export function markRuntimeStart() {
+  lastRestartAt = new Date();
+  cpuBaseline = process.cpuUsage();
+}
+
+function formatCpuUsage(usage) {
+  const userSeconds = usage.user / 1e6;
+  const systemSeconds = usage.system / 1e6;
+  return {
+    user: userSeconds,
+    system: systemSeconds,
+    total: userSeconds + systemSeconds
+  };
+}
+
+function formatMemoryUsage(usage) {
+  return {
+    rss: usage.rss,
+    heapTotal: usage.heapTotal,
+    heapUsed: usage.heapUsed,
+    external: usage.external,
+    arrayBuffers: usage.arrayBuffers
+  };
+}
+
+export function collectRuntimeMetrics() {
+  const memoryUsage = process.memoryUsage();
+  const cpuUsage = process.cpuUsage(cpuBaseline);
+  const uptimeMs = Math.max(0, Date.now() - lastRestartAt.getTime());
+
+  return {
+    timestamp: new Date().toISOString(),
+    lastRestart: lastRestartAt.toISOString(),
+    uptime: {
+      milliseconds: uptimeMs,
+      seconds: uptimeMs / 1000
+    },
+    memory: formatMemoryUsage(memoryUsage),
+    cpu: formatCpuUsage(cpuUsage),
+    process: {
+      pid: process.pid,
+      nodeVersion: process.version,
+      platform: process.platform,
+      arch: process.arch
+    },
+    system: {
+      hostname: os.hostname()
+    }
+  };
+}

--- a/server/types.js
+++ b/server/types.js
@@ -162,6 +162,12 @@ export let DashboardConfig;
 export let AuthConfig;
 
 /**
+ * @typedef {Object} HealthCheckConfig
+ * @property {boolean} enabled
+ */
+export let HealthCheckConfig;
+
+/**
  * @typedef {Object} SupervisordDefaults
  * @property {'http' | 'https'} protocol
  * @property {string} host
@@ -205,6 +211,7 @@ export let HostCache;
  * @property {string} sessionSecret
  * @property {SessionConfig} session
  * @property {AuthConfig} auth
+ * @property {HealthCheckConfig} healthCheck
  * @property {DashboardConfig} dashboard
  * @property {SupervisordConfig} supervisord
  * @property {HostCache} hostCache


### PR DESCRIPTION
## Summary
- add a runtime metrics helper and expose an optional JSON health endpoint at `/health`
- allow the endpoint to be toggled with the `HEALTH_ENDPOINT_ENABLED` environment variable
- document the configuration in the README and `.env-example`

## Testing
- npm test -- --watch=false *(fails: existing Jest ESM import errors for shared role exports)*

------
https://chatgpt.com/codex/tasks/task_e_68d6bd09b1f0832e8ab40f6799279479