### PR TITLE
Ensure host cache refresh completes before shutdown

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -86,7 +86,7 @@ export async function start() {
     unregisterSignalHandlers();
     if (typeof stopHostRefresh === 'function') {
       try {
-        stopHostRefresh();
+        await stopHostRefresh();
       } catch (stopErr) {
         console.error('Failed to stop host refresh timer', stopErr);
       }
@@ -111,7 +111,7 @@ export async function shutdown({ signal } = {}) {
 
     if (typeof stopHostRefresh === 'function') {
       try {
-        stopHostRefresh();
+        await stopHostRefresh();
       } catch (err) {
         console.error('Failed to stop host refresh timer', err);
       }

--- a/server/types.js
+++ b/server/types.js
@@ -191,7 +191,7 @@ export let SupervisordConfig;
  * @typedef {Object} HostCache
  * @property {(db: Knex) => Promise<HostRegistry>} warm
  * @property {(db: Knex) => Promise<HostRegistry>} refresh
- * @property {(db: Knex, options?: { intervalMs?: number; logger?: Console }) => () => void} scheduleRefresh
+ * @property {(db: Knex, options?: { intervalMs?: number; logger?: Console }) => () => Promise<void>} scheduleRefresh
  * @property {(id: string | number) => HostRecord | null} get
  * @property {() => HostRecord[]} getAll
  * @property {(id: string | number) => HostOverride | null} getOverride
@@ -217,7 +217,7 @@ export let HostCache;
  * @property {HostCache} hostCache
  * @property {(db: Knex) => Promise<HostRegistry>} warmHosts
  * @property {(db: Knex) => Promise<HostRegistry>} refreshHosts
- * @property {(db: Knex, options?: { intervalMs?: number; logger?: Console }) => () => void} scheduleHostRefresh
+ * @property {(db: Knex, options?: { intervalMs?: number; logger?: Console }) => () => Promise<void>} scheduleHostRefresh
  * @property {(id: string | number) => HostOverride | null} getHostOverride
  */
 export let ServerConfig;


### PR DESCRIPTION
## Summary
- queue host cache refresh operations and wait for in-flight refreshes when stopping the scheduler
- await host cache shutdown before tearing down database connections to prevent sqlite errors
- document the asynchronous shutdown contract for host refresh utilities

## Testing
- npm test -- --runTestsByPath __tests__/app.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d6bfd1aa60832e8a8b99f3be558689