### PR TITLE
Refresh session user role on each request

### DIFF
--- a/__tests__/routes/apiValidation.test.js
+++ b/__tests__/routes/apiValidation.test.js
@@ -351,7 +351,7 @@ function createTestApp(mountPath, router) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    req.session = { loggedIn: true, user: { role: 'Admin' } };
+    req.session = { loggedIn: true, user: { role: ROLE_ADMIN } };
     next();
   });
   app.use(mountPath, router);

--- a/__tests__/services/supervisordService.stream.test.js
+++ b/__tests__/services/supervisordService.stream.test.js
@@ -30,6 +30,7 @@ describe('SupervisordService.createProcessStream interval bounds', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
+    jest.spyOn(global, 'setTimeout');
     service = new SupervisordService({
       config: { hosts: {} },
       supervisordapi: { connect: jest.fn() },
@@ -43,6 +44,9 @@ describe('SupervisordService.createProcessStream interval bounds', () => {
   afterEach(() => {
     if (service?.fetchAllProcessInfo) {
       service.fetchAllProcessInfo.mockReset();
+    }
+    if (jest.isMockFunction(global.setTimeout)) {
+      global.setTimeout.mockRestore();
     }
     jest.clearAllTimers();
     jest.useRealTimers();


### PR DESCRIPTION
## Summary
- refresh the authenticated session user from the repository on each request so role changes take effect immediately
- extend the application tests to cover session updates and permission downgrades in-flight
- adjust supporting tests to use canonical role constants and to locate nested routes and timer mocks reliably

## Testing
- npm test -- __tests__/app.test.js --runInBand
- npm test -- __tests__/routes/apiValidation.test.js --runInBand
- npm test -- __tests__/routes/supervisordErrors.test.js --runInBand
- npm test -- __tests__/services/supervisordService.stream.test.js --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68d6c08b702c832e9cb7e8758d13f940