### PR TITLE
Add collapsible host tables on dashboard

### DIFF
--- a/client/src/Dashboard.module.css
+++ b/client/src/Dashboard.module.css
@@ -36,6 +36,47 @@
   flex-wrap: wrap;
 }
 
+.hostHeaderControls {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.hostToggleButton {
+  border: none;
+  background: none;
+  color: var(--nv-color-secondary);
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: var(--nv-radius-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.hostToggleButton:hover,
+.hostToggleButton:focus-visible {
+  background-color: var(--nv-color-surface-muted);
+  color: var(--nv-color-secondary);
+}
+
+.hostToggleButton:focus-visible {
+  outline: 2px solid var(--nv-color-primary);
+  outline-offset: 2px;
+}
+
+.hostToggleIcon {
+  width: 1.1rem;
+  height: 1.1rem;
+  transition: transform 0.2s ease;
+}
+
+.hostToggleButtonExpanded .hostToggleIcon {
+  transform: rotate(90deg);
+}
+
 .hostTitle {
   margin: 0;
   font-size: 1.5rem;


### PR DESCRIPTION
## Summary
- add a chevron button to each dashboard host card that toggles the services table and persists the state per-host via localStorage
- style the new toggle control so the header layout accommodates the chevron affordance

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d70487ac48832e9d9e3a0eafed655a