### PR TITLE
docs: expand apache and supervisor setup instructions

### DIFF
--- a/config/apache/nodervisor.conf
+++ b/config/apache/nodervisor.conf
@@ -1,0 +1,29 @@
+<IfModule mod_ssl.c>
+<VirtualHost *:443>
+    ServerName example.com
+    ServerAlias www.example.com
+
+    SSLEngine on
+    SSLCertificateFile /etc/letsencrypt/live/example.com/fullchain.pem
+    SSLCertificateKeyFile /etc/letsencrypt/live/example.com/privkey.pem
+
+    ProxyPreserveHost On
+    ProxyPass / http://127.0.0.1:3000/
+    ProxyPassReverse / http://127.0.0.1:3000/
+
+    RequestHeader set X-Forwarded-Proto "https"
+    RequestHeader set X-Forwarded-Port "443"
+
+    ErrorLog ${APACHE_LOG_DIR}/nodervisor-error.log
+    CustomLog ${APACHE_LOG_DIR}/nodervisor-access.log combined
+</VirtualHost>
+</IfModule>
+
+<VirtualHost *:80>
+    ServerName example.com
+    ServerAlias www.example.com
+
+    RewriteEngine On
+    RewriteCond %{HTTPS} !=on
+    RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R=301,L]
+</VirtualHost>


### PR DESCRIPTION
## Summary
- document the full Apache and Supervisor setup flow, including package installation, module enabling, TLS guidance, symlinks, and Supervisord configuration needed to run Nodervisor
- add a ready-to-link Apache virtual host file under `config/apache/` that matches the documented reverse proxy settings

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d7072ad1b8832ebf75c1b004224201