### PR TITLE
Show running/stopped process counts in host header

### DIFF
--- a/client/src/Dashboard.jsx
+++ b/client/src/Dashboard.jsx
@@ -678,6 +678,14 @@ function HostPanel({ entry, onProcessAction, onViewLogs }) {
       : hostProcessCount === 0
       ? 'No services reported.'
       : `${hostProcessCount} ${hostProcessCount === 1 ? 'service' : 'services'}`;
+  const runningCount = Array.isArray(processes)
+    ? processes.filter((proc) => proc?.statename === 'RUNNING').length
+    : 0;
+  const stoppedCount = Array.isArray(processes)
+    ? processes.filter((proc) => proc?.statename === 'STOPPED').length
+    : 0;
+  const shouldShowSummaryBadge =
+    summary.status !== 'CONERR' && summary.status !== 'RUNNING' && summary.status !== 'STOPPED';
   const [expanded, setExpanded] = useState(() => readHostExpansion(hostId, false));
   const hostBodyId = useMemo(() => getHostBodyId(hostId), [hostId]);
 
@@ -741,7 +749,40 @@ function HostPanel({ entry, onProcessAction, onViewLogs }) {
             </svg>
           </button>
           <div className={dashboardStyles.hostStats}>
-            <StatusBadge status={summary.status}>{summaryLabel}</StatusBadge>
+            <div className={dashboardStyles.hostStatusPills}>
+              {summary.status === 'CONERR' ? (
+                <StatusBadge status={summary.status}>{summaryLabel}</StatusBadge>
+              ) : (
+                <>
+                  {shouldShowSummaryBadge && (
+                    <StatusBadge status={summary.status}>{summaryLabel}</StatusBadge>
+                  )}
+                  <span
+                    className={classNames(
+                      dashboardStyles.hostStatusPill,
+                      dashboardStyles.hostStatusPillRunning
+                    )}
+                  >
+                    <StatusIcon
+                      name={STATUS_META.RUNNING.icon}
+                      className={dashboardStyles.hostStatusPillIcon}
+                    />
+                    <span>{`${runningCount} running`}</span>
+                  </span>
+                  {stoppedCount > 0 && (
+                    <span
+                      className={classNames(
+                        dashboardStyles.hostStatusPill,
+                        dashboardStyles.hostStatusPillStopped
+                      )}
+                    >
+                      <StatusIcon name="pause" className={dashboardStyles.hostStatusPillIcon} />
+                      <span>{`${stoppedCount} stopped`}</span>
+                    </span>
+                  )}
+                </>
+              )}
+            </div>
             <span className={dashboardStyles.hostProcessCount}>{processLabel}</span>
           </div>
         </div>

--- a/client/src/Dashboard.module.css
+++ b/client/src/Dashboard.module.css
@@ -108,6 +108,38 @@
   color: var(--nv-color-text-muted);
 }
 
+.hostStatusPills {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.hostStatusPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.95rem;
+}
+
+.hostStatusPillIcon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.hostStatusPillRunning {
+  background-color: var(--nv-color-status-success-bg);
+  color: var(--nv-color-status-success-text);
+}
+
+.hostStatusPillStopped {
+  background-color: var(--nv-color-status-danger-bg);
+  color: var(--nv-color-status-danger-text);
+}
+
 .statusBadge {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- replace the host header status label with a running process count and optional stopped count
- add styling for the new status pills while preserving the existing badge when severe states are present

## Testing
- npm run lint *(fails: existing unused variable and regex lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d70f8f9088832eb2cbd8d816ecb211