### PR TITLE
Preserve existing logs when auto refresh finds no updates

### DIFF
--- a/client/src/Dashboard.jsx
+++ b/client/src/Dashboard.jsx
@@ -266,7 +266,11 @@ function ProcessLogDialog({ open, hostId, hostName, processName, displayName, on
           const nextOffset = Number.isFinite(Number(offset)) ? Number(offset) : 0;
           const newContent = typeof content === 'string' ? content : '';
           const canAppend = shouldAppend && nextOffset > previousTab.offset;
-          const combinedContent = canAppend ? `${previousTab.content}${newContent}` : newContent;
+          const combinedContent = shouldAppend
+            ? canAppend
+              ? `${previousTab.content}${newContent}`
+              : previousTab.content
+            : newContent;
           if (shouldAppend && shouldStickToBottom && typeof newContent === 'string' && newContent.length > 0) {
             shouldScrollAfterUpdate = true;
           }


### PR DESCRIPTION
## Summary
- keep previously loaded log output when an auto-refresh returns no new content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deeae11228832ebe29fc16e10b032c